### PR TITLE
chore: use iife instead babel + amd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ examples/workbox-cli/esm-sw*.js
 examples/workbox-cli/esm-sw*.map
 examples/workbox-cli/sw*.js
 examples/workbox-cli/sw*.map
+examples/workbox-cli/workbox.js
 examples/workbox-cli/workbox-*.js
 examples/workbox-cli/workbox-*.map

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ dist-ssr
 # examples
 examples/workbox-cli/classic-sw*.js
 examples/workbox-cli/classic-sw*.map
+examples/workbox-cli/esm-sw*.js
+examples/workbox-cli/esm-sw*.map
 examples/workbox-cli/sw*.js
 examples/workbox-cli/sw*.map
 examples/workbox-cli/workbox-*.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ export default antfu({
     'examples/workbox-cli/esm-sw*.js',
     'examples/workbox-cli/classic-sw*.js',
     'examples/workbox-cli/sw*.js',
+    'examples/workbox-cli/workbox.js',
     'examples/workbox-cli/workbox*.js',
   ],
 })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ export default antfu({
   ignores: [
     '**/dist/**',
     '**/dev-dist/**',
+    'examples/workbox-cli/esm-sw*.js',
     'examples/workbox-cli/classic-sw*.js',
     'examples/workbox-cli/sw*.js',
     'examples/workbox-cli/workbox*.js',

--- a/examples/workbox-cli/generate.ts
+++ b/examples/workbox-cli/generate.ts
@@ -63,7 +63,7 @@ generateSW({
   cleanupOutdatedCaches: true,
   disableDevLogs: false,
   sourcemap: true,
-  swType: 'classic-and-module',
+  swType: 'classic',
   urlManipulation: ({ url }) => {
     return [url]
   },

--- a/examples/workbox-cli/generate.ts
+++ b/examples/workbox-cli/generate.ts
@@ -63,7 +63,7 @@ generateSW({
   cleanupOutdatedCaches: true,
   disableDevLogs: false,
   sourcemap: true,
-  swType: 'classic',
+  swType: 'classic-and-module',
   urlManipulation: ({ url }) => {
     return [url]
   },
@@ -71,5 +71,6 @@ generateSW({
   inlineWorkboxRuntime: false,
   runtimeCaching,
 }).then((result) => {
+  // eslint-disable-next-line no-console
   console.log(result)
 })

--- a/examples/workbox-cli/generate.ts
+++ b/examples/workbox-cli/generate.ts
@@ -1,9 +1,29 @@
+// import { prepareSWCode } from '@composable-vite-pwa/workbox-build/utils/prepare-sw-code'
+
 import { generateSW } from '@composable-vite-pwa/workbox-build/generate-sw'
 import { runtimeCaching } from './cache'
 
-generateSW({
+/* prepareSWCode({
   globDirectory: './',
-  globPatterns: ['**/*.{js,html}'],
+  globPatterns: ['**!/!*.{js,html}'],
+  skipWaiting: true,
+  navigateFallback: 'index.html',
+  cleanupOutdatedCaches: true,
+  disableDevLogs: false,
+  sourcemap: true,
+  swType: 'classic-and-module',
+  inlineWorkboxRuntime: false,
+  urlManipulation: ({ url }) => {
+    return [url]
+  },
+  swDest: 'sw.js',
+  runtimeCaching,
+}).then((result) => {
+  console.log(result)
+}) */
+/* generateSW({
+  globDirectory: './',
+  globPatterns: ['**!/!*.{js,html}'],
   skipWaiting: true,
   navigateFallback: 'index.html',
   cleanupOutdatedCaches: true,
@@ -17,7 +37,7 @@ generateSW({
   runtimeCaching,
 }).then((result) => {
   console.log(result)
-})
+}) */
 // generateSW({
 //   globDirectory: './',
 //   globPatterns: ['**/*.{js,html}'],
@@ -35,9 +55,9 @@ generateSW({
 // }).then(result => {
 //   console.log(result)
 // })
-/* generateSW({
+generateSW({
   globDirectory: './',
-  globPatterns: ['**!/!*.{js,html}'],
+  globPatterns: ['**/*.{js,html}'],
   skipWaiting: true,
   navigateFallback: 'index.html',
   cleanupOutdatedCaches: true,
@@ -48,10 +68,8 @@ generateSW({
     return [url]
   },
   swDest: 'sw.js',
+  inlineWorkboxRuntime: false,
   runtimeCaching,
-}).then(({ classic, module }) => {
-  console.log('CLASSIC:')
-  console.log(classic)
-  console.log('MODULE:')
-  console.log(module)
-}) */
+}).then((result) => {
+  console.log(result)
+})

--- a/examples/workbox-cli/index.html
+++ b/examples/workbox-cli/index.html
@@ -5,8 +5,8 @@
         window.addEventListener('load', () => {
             // navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'module' })
             // navigator.serviceWorker.register('/classic-sw.js', { scope: '/', type: 'classic' })
-            navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'classic' })
-            // navigator.serviceWorker.register('/esm-sw-temp.js', { scope: '/', type: 'classic' })
+            // navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'classic' })
+            navigator.serviceWorker.register('/esm-sw.js', { scope: '/', type: 'module' })
         })
     }
 </script>

--- a/examples/workbox-cli/index.html
+++ b/examples/workbox-cli/index.html
@@ -3,8 +3,10 @@
 <script>
     if('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'module' })
+            // navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'module' })
             // navigator.serviceWorker.register('/classic-sw.js', { scope: '/', type: 'classic' })
+            navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'classic' })
+            // navigator.serviceWorker.register('/esm-sw-temp.js', { scope: '/', type: 'classic' })
         })
     }
 </script>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.2",
   "description": "Composable Vite PWA",
   "author": "userquin <userquin@gmail.com>",
   "license": "MIT",

--- a/packages/core/src/client/esm-sw-detector.ts
+++ b/packages/core/src/client/esm-sw-detector.ts
@@ -19,7 +19,7 @@ type SWFeatures = (versions: number[], os?: OS) => boolean
 
 const chromiumCheck: SWFeatures = v => v.length > 0 && !Number.isNaN(v[0]) && v[0] >= 91
 
-// https://caniuse.com/?search=service+worker
+// https://caniuse.com/?search=service+worker => 2026-04-09
 const allowedBrowsers: Record<Browser, SWFeatures> = {
   'chrome': chromiumCheck,
   'edge-chromium': chromiumCheck,
@@ -49,6 +49,10 @@ const webviewRegex = /wv\).*Chrom(?:e|ium)\/([\d.]+)/
 const operaMobileRegex = /Mobile/
 const ucBrowserRegex = /UCBrowser\/([\d.]+)/
 const qqRegex = /(MQQBrowser|QQBrowser)\/([\d.]+)/i
+const iOSRegex = /iP(?:hone|od|ad)/
+const androidRegex = /Android/
+const macOSRegex = /Macintosh/
+const splitRegexp = /[._]/
 
 const rules: Record<Browser, Rule> = {
   'chrome': (userAgent, os) => (!os || os !== 'Android') ? chromeRegex.exec(userAgent) : null,
@@ -73,18 +77,18 @@ export function isSWModuleSupported(userAgent = navigator.userAgent): boolean {
     return false
 
   let os: OS | undefined
-  if (/iP(?:hone|od|ad)/.test(userAgent))
+  if (iOSRegex.test(userAgent))
     os = 'iOS'
-  else if (/Android/.test(userAgent))
+  else if (androidRegex.test(userAgent))
     os = 'Android'
-  else if (/Macintosh/.test(userAgent))
+  else if (macOSRegex.test(userAgent))
     os = 'Mac OS'
 
   if (os === 'iOS') {
     const match = rules['ios-safari'](userAgent, os)
     return match
       ? allowedBrowsers['ios-safari'](
-          match[1].split(/[._]/).map(v => Number.parseInt(v, 10)),
+          match[1].split(splitRegexp).map(v => Number.parseInt(v, 10)),
           os,
         )
       : false
@@ -98,7 +102,7 @@ export function isSWModuleSupported(userAgent = navigator.userAgent): boolean {
     if (match) {
       const config = allowedBrowsers[name as Browser]
       return config(
-        match[1].split(/[._]/).map(v => Number.parseInt(v, 10)),
+        match[1].split(splitRegexp).map(v => Number.parseInt(v, 10)),
         os,
       )
     }

--- a/packages/workbox/build/package.json
+++ b/packages/workbox/build/package.json
@@ -59,14 +59,18 @@
     "tsx:test": "tsx ./src/generate-sw.ts"
   },
   "peerDependencies": {
-    "tsdown": "^0.21.10",
     "rolldown": "^1.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "rolldown": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@composable-vite-pwa/workbox-swkit": "workspace:*",
     "@composable-vite-pwa/workbox-window": "workspace:*",
-    "magicast": "catalog:utils",
     "magic-string": "catalog:utils",
+    "magicast": "catalog:utils",
     "picocolors": "catalog:utils",
     "pkg-types": "catalog:utils",
     "proper-tags": "catalog:utils",

--- a/packages/workbox/build/package.json
+++ b/packages/workbox/build/package.json
@@ -59,17 +59,10 @@
     "tsx:test": "tsx ./src/generate-sw.ts"
   },
   "peerDependencies": {
-    "tsdown": "^0.21.10"
-  },
-  "peerDependenciesMeta": {
-    "tsdown": {
-      "optional": true
-    }
+    "tsdown": "^0.21.10",
+    "rolldown": "^1.0.0-0"
   },
   "dependencies": {
-    "@babel/core": "catalog:babel",
-    "@babel/plugin-transform-modules-amd": "catalog:babel",
-    "@babel/plugin-transform-dynamic-import": "catalog:babel",
     "@composable-vite-pwa/workbox-swkit": "workspace:*",
     "@composable-vite-pwa/workbox-window": "workspace:*",
     "magicast": "catalog:utils",
@@ -82,6 +75,7 @@
     "valibot": "catalog:utils"
   },
   "devDependencies": {
-    "@types/serialize-javascript": "catalog:types"
+    "@types/serialize-javascript": "catalog:types",
+    "rolldown": "catalog:utils"
   }
 }

--- a/packages/workbox/build/src/generate-sw.ts
+++ b/packages/workbox/build/src/generate-sw.ts
@@ -1,6 +1,5 @@
-import type { GenerateSWOptions, SWType } from './types'
-import type { GenerateSWResult } from './utils/types'
+import type { BuildResult, GenerateSWOptions, SWType } from './types'
 
-export async function generateSW<T extends SWType>(options: GenerateSWOptions<T>): Promise<GenerateSWResult<T>> {
+export async function generateSW<T extends SWType>(options: GenerateSWOptions<T>): Promise<BuildResult> {
   return await import('./utils/build-generate-sw').then(({ buildGenerateSW }) => buildGenerateSW(options))
 }

--- a/packages/workbox/build/src/types.ts
+++ b/packages/workbox/build/src/types.ts
@@ -201,6 +201,15 @@ export interface GeneratePartial<T extends SWType> {
    */
   swType?: T
   /**
+   * When using `classic` and splitting workbox runtime (inlineWorkboxRuntime set to false), this flag controls the
+   * name of the `workbox-**.js` chunk:
+   * - when true, workbox will generate the same old asset name `workbox-<hash>.js`
+   * - when false, workbox will generate `classic-workbox-<hash>.js`.
+   *
+   * @default true
+   */
+  classicWorkboxRuntimeCompatible?: boolean
+  /**
    * The [targets](https://babeljs.io/docs/en/babel-preset-env#targets) to pass
    * to `babel-preset-env` when transpiling the service worker bundle.
    * @default ["chrome >= 56"]
@@ -459,7 +468,7 @@ export interface RequiredSWDestPartial {
   swDest: string
 }
 
-export type GenerateSWOptions<T> = BasePartial
+export type GenerateSWOptions<T extends SWType> = BasePartial
   & GlobPartial
   & GeneratePartial<T>
   & RequiredSWDestPartial

--- a/packages/workbox/build/src/utils/build-generate-sw.ts
+++ b/packages/workbox/build/src/utils/build-generate-sw.ts
@@ -1,167 +1,325 @@
 import type { BuildResult, GenerateSWOptions, SWType } from '../types'
-import type { GenerateSWResult } from './types'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
+import MagicString from 'magic-string'
 import { deepMergeObject } from 'magicast/helpers'
+import { build } from 'tsdown'
 import { validateGenerateSW } from '../validation/validation-helper'
 import { prepareSWCode } from './prepare-sw-code'
 
-export async function buildGenerateSW<T extends SWType>(options: GenerateSWOptions<T>): Promise<GenerateSWResult<T>> {
+export async function buildGenerateSW<T extends SWType>(options: GenerateSWOptions<T>): Promise<BuildResult> {
   const optionsWithDefaults = await validateGenerateSW(options)
 
   deepMergeObject(options, optionsWithDefaults)
 
-  return await prepareTSDown(options).then(build => build())
+  return await buildAssets(options)
 }
 
 function prepareGlobIgnores(
   options: GenerateSWOptions<SWType>,
-): string {
-  const { swDest } = options
+): {
+  sw: string
+  swTemp: string
+  classic: string
+  classicTemp: string
+  esm: string
+  esmTemp: string
+} {
   const entry = options.swDest.replace('.js', '.temp.js')
-  const parts = swDest.split('/')
-  const fileName = parts.pop()
+  const parts = options.swDest.split('/')
+  const fileName = parts.pop()!
   const p = parts.join('/')
 
   const classic = `${p ? `${p}/` : ''}classic-${fileName}`
+  const classicTemp = `${p ? `${p}/` : ''}classic-${fileName.replace('.js', '.temp.js')}`
+  const esm = `${p ? `${p}/` : ''}esm-${fileName}`
+  const esmTemp = `${p ? `${p}/` : ''}esm-${fileName.replace('.js', '.temp.js')}`
 
   options.globIgnores ??= []
-  options.globIgnores.push(swDest)
+  options.globIgnores.push(options.swDest)
   options.globIgnores.push(classic)
+  options.globIgnores.push(esm)
   options.globIgnores.push('**/workbox-*.js')
   // add temp sw
   options.globIgnores.push(entry)
+  options.globIgnores.push(classicTemp)
+  options.globIgnores.push(esmTemp)
   if (options.sourcemap) {
-    options.globIgnores.push(`${swDest}.map`)
+    options.globIgnores.push(`${options.swDest}.map`)
     options.globIgnores.push(`${classic}.map`)
+    options.globIgnores.push(`${esm}.map`)
+    options.globIgnores.push('**/workbox-*.js.map')
     // add temp sw map
     options.globIgnores.push(`${entry}.map`)
-    options.globIgnores.push('**/workbox-*.js.map')
   }
-
-  return classic
-}
-
-const CLASSIC_SW_AMD_PREFIX = `if (!self.define) {
-  let registry = {};
-
-  // Used for \`eval\` and \`importScripts\` where we can't get script URL by other means.
-  // In both cases, it's safe to use a global var because those functions are synchronous.
-  let nextDefineUri;
-
-  const singleRequire = (uri, parentUri) => {
-    uri = new URL(uri, parentUri).href;
-    return registry[uri] || (
-      
-        new Promise(resolve => {
-          nextDefineUri = uri;
-          importScripts(uri);
-          resolve();
-        })
-      
-      .then(() => {
-        let promise = registry[uri];
-        if (!promise) {
-          throw new Error(\`Module \${uri} didn’t register its module\`);
-        }
-        return promise;
-      })
-    );
-  };
-
-  self.define = (depsNames, factory) => {
-    const uri = nextDefineUri || ("document" in self ? document.currentScript.src : "") || location.href;
-    // Module is already loading or loaded.
-    if (registry[uri]) {
-      return;
-    }
-    let exports = {};
-    const require = depUri => singleRequire(depUri, uri);
-    const specialDeps = {
-      module: { uri },
-      exports,
-      require
-    };
-    registry[uri] = Promise.all(depsNames.map(
-      depName => specialDeps[depName] || require(depName)
-    )).then(deps => {
-      factory(...deps);
-      return exports;
-    });
-  };
-}`
-
-async function prepareClassicSWCode(swCode: string, sourcemap: boolean): Promise<{
-  code: string
-  map?: string
-}> {
-  if (!sourcemap) {
-    return { code: `${CLASSIC_SW_AMD_PREFIX}\n${swCode}` }
-  }
-
-  const MagicString = await import('magic-string').then(m => m.default || m)
-  const s = new MagicString(swCode)
-  s.prepend(CLASSIC_SW_AMD_PREFIX)
 
   return {
-    code: s.toString(),
-    map: sourcemap ? s.generateMap({ hires: true }).toString() : undefined,
+    sw: options.swDest,
+    swTemp: entry,
+    classic,
+    classicTemp,
+    esm,
+    esmTemp,
   }
 }
 
-async function prepareTSDown<T extends SWType>(options: GenerateSWOptions<T>): Promise<() => Promise<GenerateSWResult<T>>> {
-  const classicSWDestName = prepareGlobIgnores(options)
-  let useMode: 'classic' | 'module' = options.swType === 'classic-and-module' ? 'classic' : options.swType
-  function resolveMode() {
-    return useMode
-  }
-  const [
-    build,
-    inputOptions,
-  ] = await Promise.all([
-    import('tsdown').then(({ build }) => build),
-    async () => {
-      if (resolveMode() === 'classic') {
-        const [babel, babelAmd, babelDynamicImport] = await Promise.all([
-          // @ts-expect-error missing types ?
-          import('@babel/core'),
-          // @ts-expect-error missing types ?
-          import('@babel/plugin-transform-modules-amd'),
-          // @ts-expect-error missing types ?
-          import('@babel/plugin-transform-dynamic-import'),
-        ])
-
-        return {
-          experimental: {
-            resolveNewUrlToAsset: true,
-          },
-          plugins: [{
-            name: 'transform-chunk-amd',
-            async renderChunk(code, { fileName }) {
-              const result = await babel.transformAsync(code, {
-                babelrc: false,
-                configFile: false,
-                sourceMaps: options.sourcemap,
-                plugins: [babelDynamicImport, babelAmd],
-              })
-
-              return fileName.startsWith('workbox')
-                ? { code: result.code, map: result.map }
-                : await prepareClassicSWCode(result.code, options.sourcemap === true)
-            },
-          }],
-        } satisfies Partial<import('tsdown').InlineConfig['inputOptions']>
+async function fixSourceMaps(
+  sourcemap: boolean,
+  swName: string,
+  swFile: string,
+  classicWorkboxRuntimeCompatible: boolean,
+  classicReplacementName?: string,
+  workbox?: {
+    tempName: string
+    name: string
+    file: string
+  },
+) {
+  await Promise.all([
+    fs.readFile(swFile, 'utf-8').then((code) => {
+      const s = new MagicString(code)
+      s.replace(
+        `//#region ${swName.replace('.js', '.temp.js')}`,
+        `//#region ${swName}`,
+      )
+      if (classicReplacementName) {
+        s.replace(
+          `importScripts("./workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js")`,
+          `importScripts("./${classicReplacementName}")`,
+        )
       }
+      return fs.writeFile(swFile, s.toString(), 'utf-8')
+    }),
+    sourcemap
+      ? fs.writeFile(
+          swFile.replace('.js', '.js.map'),
+          await fs.readFile(
+            swFile.replace('.js', '.js.map'),
+            'utf-8',
+          ).then((code) => {
+            return code.replace(
+              `"${swName.replace('.js', '.temp.js')}"`,
+              `"${swName}"`,
+            )
+          }),
+          'utf-8',
+        )
+      : undefined,
+    sourcemap && workbox
+      ? fs.writeFile(
+          workbox.file.replace('.js', '.js.map'),
+          await fs.readFile(
+            workbox.file.replace('.js', '.js.map'),
+            'utf-8',
+          ).then((code) => {
+            return code.replace(
+              `"${workbox.tempName}"`,
+              `"${workbox.name}"`,
+            )
+          }),
+          'utf-8',
+        )
+      : undefined,
+  ].filter(Boolean))
+}
 
-      return undefined
+async function buildClassicSW(
+  rootDir: string,
+  swName: string,
+  tempSwName: string,
+  inline: boolean,
+  sourcemap: boolean,
+  define: import('tsdown').InlineConfig['define'],
+  workboxRegex: RegExp[],
+  filePaths: string[],
+  classicWorkboxRuntimeCompatible: boolean,
+  workboxClassicFileForSourceMap?: string,
+) {
+  const workbox = path.resolve(rootDir, `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js`)
+  let workboxClassicFile: string | undefined
+  const tempSWFile = path.resolve(rootDir, tempSwName)
+  await build({
+    dts: false,
+    clean: false,
+    entry: inline ? tempSwName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js`,
+    platform: 'browser',
+    fromVite: false,
+    format: 'iife',
+    outDir: rootDir,
+    define,
+    sourcemap,
+    outputOptions: {
+      comments: {
+        legal: true,
+        jsdoc: false,
+        annotation: false,
+      },
+      chunkFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
+      assetFileNames: '[name]-[hash].[ext]',
+      entryFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
+      codeSplitting: false,
     },
-  ])
+    hooks: {
+      'build:done': async ({ chunks }) => {
+        for (const chunk of chunks) {
+          filePaths.push(path.resolve(rootDir, chunk.fileName))
+        }
+        if (inline) {
+          await fs.rm(tempSWFile, { force: true })
+          return
+        }
+        await fs.rm(workbox, { force: true })
+        workboxClassicFile = chunks.find(chunk => chunk.name === `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}`)?.fileName
+      },
+    },
+  })
 
-  const { swCode, ...entriesResult } = await prepareSWCode(options)
+  if (workboxClassicFile) {
+    await buildClassicSW(
+      rootDir,
+      swName,
+      tempSwName,
+      true,
+      sourcemap,
+      define,
+      workboxRegex,
+      filePaths,
+      classicWorkboxRuntimeCompatible,
+      workboxClassicFile,
+    )
+    return
+  }
+
+  if (!inline) {
+    throw new Error('workbox-classic-<hash>.js assets not found!')
+  }
+
+  await fixSourceMaps(
+    sourcemap,
+    swName,
+    path.resolve(rootDir, swName),
+    classicWorkboxRuntimeCompatible,
+    workboxClassicFileForSourceMap,
+    !inline && sourcemap
+      ? {
+          tempName: 'workbox-classic.js',
+          name: workboxClassicFileForSourceMap!,
+          file: path.resolve(rootDir, workboxClassicFileForSourceMap!),
+        }
+      : undefined,
+  )
+}
+
+async function buildESMSW(
+  rootDir: string,
+  swName: string,
+  tempSwName: string,
+  inline: boolean,
+  sourcemap: boolean,
+  define: import('tsdown').InlineConfig['define'],
+  workboxRegex: RegExp[],
+  filePaths: string[],
+) {
+  const swChunkName = tempSwName.replace('.js', '')
+  const tempSWFile = path.resolve(rootDir, tempSwName)
+  let workboxModuleFile: string | undefined
+  await build({
+    dts: false,
+    clean: false,
+    entry: tempSwName,
+    platform: 'browser',
+    fromVite: false,
+    format: 'esm',
+    outDir: rootDir,
+    define,
+    sourcemap,
+    outputOptions: {
+      comments: {
+        legal: true,
+        jsdoc: false,
+        annotation: false,
+      },
+      chunkFileNames: (chunk) => {
+        switch (chunk.name) {
+          case 'workbox-module':
+            return 'workbox-module-[hash].js'
+          case swChunkName:
+            return swName
+          default:
+            return '[name]-[hash].[ext]'
+        }
+      },
+      assetFileNames: '[name]-[hash].[ext]',
+      entryFileNames: (chunk) => {
+        switch (chunk.name) {
+          case 'workbox-module':
+            return 'workbox-module-[hash].js'
+          case swChunkName:
+            return swName
+          default:
+            return '[name]-[hash].js'
+        }
+      },
+      codeSplitting: inline
+        ? false
+        : {
+            groups: [
+              {
+                minSize: 0,
+                name: (moduleId) => {
+                  return workboxRegex.some(r => r.test(moduleId)) ? 'workbox-module' : undefined
+                },
+              },
+            ],
+          },
+    },
+    hooks: {
+      'build:done': async ({ chunks }) => {
+        for (const chunk of chunks) {
+          filePaths.push(path.resolve(rootDir, chunk.fileName))
+        }
+        await fs.rm(tempSWFile, { force: true })
+        if (!inline) {
+          workboxModuleFile = chunks.find(chunk => chunk.name === 'workbox-module')?.fileName
+        }
+      },
+    },
+  })
+
+  await fixSourceMaps(
+    sourcemap,
+    swName,
+    path.resolve(rootDir, swName),
+    false,
+    undefined,
+    !inline && sourcemap
+      ? {
+          tempName: 'workbox-module.js',
+          name: workboxModuleFile!,
+          file: path.resolve(rootDir, workboxModuleFile!),
+        }
+      : undefined,
+  )
+}
+
+async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Promise<BuildResult> {
+  const {
+    sw,
+    swTemp,
+    classic,
+    classicTemp,
+    esm,
+    esmTemp,
+  } = prepareGlobIgnores(options)
+  const rootDir = options.globDirectory ? path.resolve(process.cwd(), options.globDirectory) : process.cwd()
+  const { manifestEntries, chunks } = await prepareSWCode(rootDir, options)
+  const inline = options.inlineWorkboxRuntime === true
+  const sourcemap = options.sourcemap === true
+  const workboxRegex = [/^@composable-vite-pwa\/workbox-swkit\//, /[\\/]workbox-swkit[\\/]/, /[\\/]workbox[\\/]swkit/]
+  const filePaths: string[] = []
 
   const define: import('tsdown').InlineConfig['define'] = {}
-
   if (options.mode) {
     define['process.env.NODE_ENV'] = JSON.stringify(options.mode)
   }
@@ -169,145 +327,85 @@ async function prepareTSDown<T extends SWType>(options: GenerateSWOptions<T>): P
     define.__WB_DISABLE_DEV_LOGS = 'true'
   }
 
-  const workboxRegex = [/[\\/]workbox-swkit[\\/]/, /workbox[\\/]swkit/]
-
-  // write once tsdown and babel are resolved
-  const entry = options.swDest.replace('.js', '.temp.js')
-  const tempDest = path.resolve(process.cwd(), entry)
-  await fs.mkdir(path.dirname(tempDest), { recursive: true })
-  await fs.writeFile(tempDest, swCode, 'utf-8')
-  let dest = path.resolve(process.cwd(), options.swDest)
-  const filePaths: string[] = []
-
-  let deleteTempSWFile = true
-
-  const inlineConfig: () => import('tsdown').InlineConfig = () => ({
-    dts: false,
-    clean: false,
-    entry,
-    platform: 'browser',
-    fromVite: false,
-    format: 'esm',
-    outDir: process.cwd(),
-    define,
-    sourcemap: options.sourcemap,
-    treeshake: true,
-    inputOptions,
-    outputOptions: () => ({
-      comments: {
-        legal: true,
-        jsdoc: false,
-        annotation: false,
-      },
-      hashCharacters: !options.inlineWorkboxRuntime ? 'hex' : undefined,
-      codeSplitting: !options.inlineWorkboxRuntime
-        ? {
-            groups: [
-              {
-                minSize: 0,
-                name: (moduleId) => {
-                  const match = workboxRegex.some(r => r.test(moduleId)) ? 'workbox' : undefined
-                  console.log(resolveMode(), moduleId, match)
-                  return match
-                },
-              },
-            ],
-          }
+  if ('classic' in chunks) {
+    await Promise.all([
+      fs.writeFile(path.resolve(rootDir, classicTemp), chunks.classic.swCode, 'utf8'),
+      fs.writeFile(path.resolve(rootDir, esmTemp), chunks.module.swCode, 'utf8'),
+      chunks.classic.workbox
+        ? fs.writeFile(path.resolve(rootDir, 'workbox-classic.js'), chunks.classic.workbox, 'utf8')
         : undefined,
-    }),
-    hooks: {
-      'build:done': async ({ chunks }) => {
-        filePaths.push(dest)
-        if (deleteTempSWFile) {
-          await fs.rename(tempDest, dest)
-        }
-        else {
-          await fs.cp(tempDest, dest, { force: true })
-        }
-        const tempDestMap = `${tempDest}.map`
-        const sourceMap = await fs.lstat(tempDestMap).then(s => s.isFile()).catch(() => false)
-        if (sourceMap) {
-          filePaths.push(`${dest}.map`)
-          await Promise.all([
-            fs.readFile(dest, 'utf-8').then(content => fs.writeFile(
-              dest,
-              content.replace(
-                `${entry}.map`,
-                `${options.swDest}.map`,
-              ).replace(
-                `//#region ${entry}`,
-                `//#region ${options.swDest}`,
-              ),
-              'utf-8',
-            )),
-            fs.readFile(tempDestMap, 'utf-8').then(content => fs.writeFile(
-              `${options.swDest}.map`,
-              content.replaceAll(
-                `"${entry}"`,
-                `"${options.swDest}"`,
-              ),
-            )).then(() => {
-              fs.rm(tempDestMap).catch(() => {})
-            }),
-          ])
-        }
-        for (const chunk of chunks) {
-          if (!chunk.fileName.startsWith('workbox')) {
-            continue
-          }
-          filePaths.push(path.resolve(chunk.outDir, chunk.fileName))
-        }
-      },
-    },
-  })
-
-  return async () => {
-    if (options.swType === 'classic' || options.swType === 'module') {
-      await build(inlineConfig())
-      const {
-        count,
-        size,
-        warnings,
-      } = entriesResult
-      return {
-        count,
+    ].filter(Boolean))
+    await Promise.all([
+      // classic
+      buildClassicSW(
+        rootDir,
+        classic,
+        classicTemp,
+        inline,
+        sourcemap,
+        define,
+        workboxRegex,
         filePaths,
-        size,
-        warnings,
-      } as GenerateSWResult<T>
-    }
-
-    // dual build: classic first then module
-    useMode = 'classic'
-    dest = path.resolve(process.cwd(), classicSWDestName)
-    deleteTempSWFile = false
-    await build(inlineConfig())
-    const {
-      count,
-      size,
-      warnings,
-    } = entriesResult
-    const classic: BuildResult = {
-      count,
-      filePaths: Array.from(filePaths),
-      size,
-      warnings: Array.from(warnings),
-    }
-    // reset data
-    useMode = 'module'
-    dest = path.resolve(process.cwd(), options.swDest)
-    filePaths.length = 0
-    // delete temp SW
-    deleteTempSWFile = true
-    await build(inlineConfig())
-    return {
-      classic,
-      module: {
-        count,
+        false,
+      ),
+      // module
+      buildESMSW(
+        rootDir,
+        esm,
+        esmTemp,
+        inline,
+        sourcemap,
+        define,
+        workboxRegex,
         filePaths,
-        size,
-        warnings,
-      },
-    } as GenerateSWResult<T>
+      ),
+    ])
+  }
+  else {
+    if (options.swType === 'classic') {
+      await Promise.all([
+        fs.writeFile(path.resolve(rootDir, swTemp), chunks.swCode, 'utf8'),
+        chunks.workbox
+          ? fs.writeFile(path.resolve(rootDir, 'workbox-classic.js'), chunks.workbox, 'utf8')
+          : undefined,
+      ].filter(Boolean))
+      await buildClassicSW(
+        rootDir,
+        sw,
+        swTemp,
+        inline,
+        sourcemap,
+        define,
+        workboxRegex,
+        filePaths,
+        options.classicWorkboxRuntimeCompatible === true,
+      )
+    }
+    else {
+      await fs.writeFile(path.resolve(rootDir, swTemp), chunks.swCode, 'utf8')
+      await buildESMSW(
+        rootDir,
+        sw,
+        swTemp,
+        inline,
+        sourcemap,
+        define,
+        workboxRegex,
+        filePaths,
+      )
+    }
+  }
+
+  const {
+    count,
+    size,
+    warnings,
+  } = manifestEntries
+
+  return {
+    count,
+    filePaths: filePaths.sort(),
+    size,
+    warnings,
   }
 }

--- a/packages/workbox/build/src/utils/build-generate-sw.ts
+++ b/packages/workbox/build/src/utils/build-generate-sw.ts
@@ -2,9 +2,7 @@ import type { BuildResult, GenerateSWOptions, SWType } from '../types'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
-import MagicString from 'magic-string'
 import { deepMergeObject } from 'magicast/helpers'
-import { build } from 'tsdown'
 import { validateGenerateSW } from '../validation/validation-helper'
 import { prepareSWCode } from './prepare-sw-code'
 
@@ -64,247 +62,14 @@ function prepareGlobIgnores(
   }
 }
 
-async function fixSourceMaps(
-  sourcemap: boolean,
-  swName: string,
-  swFile: string,
-  classicWorkboxRuntimeCompatible: boolean,
-  classicReplacementName?: string,
-  workbox?: {
-    tempName: string
-    name: string
-    file: string
-  },
-) {
-  await Promise.all([
-    fs.readFile(swFile, 'utf-8').then((code) => {
-      const s = new MagicString(code)
-      s.replace(
-        `//#region ${swName.replace('.js', '.temp.js')}`,
-        `//#region ${swName}`,
-      )
-      if (classicReplacementName) {
-        s.replace(
-          `importScripts("./workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js")`,
-          `importScripts("./${classicReplacementName}")`,
-        )
-      }
-      return fs.writeFile(swFile, s.toString(), 'utf-8')
-    }),
-    sourcemap
-      ? fs.writeFile(
-          swFile.replace('.js', '.js.map'),
-          await fs.readFile(
-            swFile.replace('.js', '.js.map'),
-            'utf-8',
-          ).then((code) => {
-            return code.replace(
-              `"${swName.replace('.js', '.temp.js')}"`,
-              `"${swName}"`,
-            )
-          }),
-          'utf-8',
-        )
-      : undefined,
-    sourcemap && workbox
-      ? fs.writeFile(
-          workbox.file.replace('.js', '.js.map'),
-          await fs.readFile(
-            workbox.file.replace('.js', '.js.map'),
-            'utf-8',
-          ).then((code) => {
-            return code.replace(
-              `"${workbox.tempName}"`,
-              `"${workbox.name}"`,
-            )
-          }),
-          'utf-8',
-        )
-      : undefined,
-  ].filter(Boolean))
+function throwMissingRolldownError(error: unknown): never {
+  throw new Error('Failed to load Rolldown. Please make sure to install it as a dev dependency or enable auto install peers in your package manager settings.', { cause: error })
 }
 
-async function buildClassicSW(
-  rootDir: string,
-  swName: string,
-  tempSwName: string,
-  inline: boolean,
-  sourcemap: boolean,
-  define: import('tsdown').InlineConfig['define'],
-  workboxRegex: RegExp[],
-  filePaths: string[],
-  classicWorkboxRuntimeCompatible: boolean,
-  workboxClassicFileForSourceMap?: string,
-) {
-  const workbox = path.resolve(rootDir, `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js`)
-  let workboxClassicFile: string | undefined
-  const tempSWFile = path.resolve(rootDir, tempSwName)
-  await build({
-    dts: false,
-    clean: false,
-    entry: inline ? tempSwName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js`,
-    platform: 'browser',
-    fromVite: false,
-    format: 'iife',
-    outDir: rootDir,
-    define,
-    sourcemap,
-    outputOptions: {
-      comments: {
-        legal: true,
-        jsdoc: false,
-        annotation: false,
-      },
-      hashCharacters: classicWorkboxRuntimeCompatible ? 'hex' : undefined,
-      chunkFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
-      assetFileNames: '[name]-[hash].[ext]',
-      entryFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
-      codeSplitting: false,
-    },
-    hooks: {
-      'build:done': async ({ chunks }) => {
-        for (const chunk of chunks) {
-          filePaths.push(path.resolve(rootDir, chunk.fileName))
-        }
-        if (inline) {
-          await fs.rm(tempSWFile, { force: true })
-          return
-        }
-        await fs.rm(workbox, { force: true })
-        workboxClassicFile = chunks.find(chunk => chunk.name === `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}`)?.fileName
-      },
-    },
-  })
-
-  if (workboxClassicFile) {
-    await buildClassicSW(
-      rootDir,
-      swName,
-      tempSwName,
-      true,
-      sourcemap,
-      define,
-      workboxRegex,
-      filePaths,
-      classicWorkboxRuntimeCompatible,
-      workboxClassicFile,
-    )
-    return
-  }
-
-  if (!inline) {
-    throw new Error('workbox-classic-<hash>.js assets not found!')
-  }
-
-  await fixSourceMaps(
-    sourcemap,
-    swName,
-    path.resolve(rootDir, swName),
-    classicWorkboxRuntimeCompatible,
-    workboxClassicFileForSourceMap,
-    !inline && sourcemap
-      ? {
-          tempName: 'workbox-classic.js',
-          name: workboxClassicFileForSourceMap!,
-          file: path.resolve(rootDir, workboxClassicFileForSourceMap!),
-        }
-      : undefined,
-  )
-}
-
-async function buildESMSW(
-  rootDir: string,
-  swName: string,
-  tempSwName: string,
-  inline: boolean,
-  sourcemap: boolean,
-  define: import('tsdown').InlineConfig['define'],
-  workboxRegex: RegExp[],
-  filePaths: string[],
-) {
-  const swChunkName = tempSwName.replace('.js', '')
-  const tempSWFile = path.resolve(rootDir, tempSwName)
-  let workboxModuleFile: string | undefined
-  await build({
-    dts: false,
-    clean: false,
-    entry: tempSwName,
-    platform: 'browser',
-    fromVite: false,
-    format: 'esm',
-    outDir: rootDir,
-    define,
-    sourcemap,
-    outputOptions: {
-      comments: {
-        legal: true,
-        jsdoc: false,
-        annotation: false,
-      },
-      chunkFileNames: (chunk) => {
-        switch (chunk.name) {
-          case 'workbox-module':
-            return 'workbox-module-[hash].js'
-          case swChunkName:
-            return swName
-          default:
-            return '[name]-[hash].[ext]'
-        }
-      },
-      assetFileNames: '[name]-[hash].[ext]',
-      entryFileNames: (chunk) => {
-        switch (chunk.name) {
-          case 'workbox-module':
-            return 'workbox-module-[hash].js'
-          case swChunkName:
-            return swName
-          default:
-            return '[name]-[hash].js'
-        }
-      },
-      codeSplitting: inline
-        ? false
-        : {
-            groups: [
-              {
-                minSize: 0,
-                name: (moduleId) => {
-                  return workboxRegex.some(r => r.test(moduleId)) ? 'workbox-module' : undefined
-                },
-              },
-            ],
-          },
-    },
-    hooks: {
-      'build:done': async ({ chunks }) => {
-        for (const chunk of chunks) {
-          filePaths.push(path.resolve(rootDir, chunk.fileName))
-        }
-        await fs.rm(tempSWFile, { force: true })
-        if (!inline) {
-          workboxModuleFile = chunks.find(chunk => chunk.name === 'workbox-module')?.fileName
-        }
-      },
-    },
-  })
-
-  await fixSourceMaps(
-    sourcemap,
-    swName,
-    path.resolve(rootDir, swName),
-    false,
-    undefined,
-    !inline && sourcemap
-      ? {
-          tempName: 'workbox-module.js',
-          name: workboxModuleFile!,
-          file: path.resolve(rootDir, workboxModuleFile!),
-        }
-      : undefined,
-  )
-}
-
-async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Promise<BuildResult> {
+async function buildAssets<T extends SWType>(
+  options: GenerateSWOptions<T>,
+): Promise<BuildResult> {
+  const rolldown = await import('./rolldown-build').catch(e => throwMissingRolldownError(e))
   const {
     sw,
     swTemp,
@@ -320,7 +85,7 @@ async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Pro
   const workboxRegex = [/^@composable-vite-pwa\/workbox-swkit\//, /[\\/]workbox-swkit[\\/]/, /[\\/]workbox[\\/]swkit/]
   const filePaths: string[] = []
 
-  const define: import('tsdown').InlineConfig['define'] = {}
+  const define: import('rolldown').TransformOptions['define'] = {}
   if (options.mode) {
     define['process.env.NODE_ENV'] = JSON.stringify(options.mode)
   }
@@ -338,19 +103,18 @@ async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Pro
     ].filter(Boolean))
     await Promise.all([
       // classic
-      buildClassicSW(
+      rolldown!.buildClassicSW(
         rootDir,
         classic,
         classicTemp,
         inline,
         sourcemap,
         define,
-        workboxRegex,
         filePaths,
         false,
       ),
       // module
-      buildESMSW(
+      rolldown!.buildModuleSW(
         rootDir,
         esm,
         esmTemp,
@@ -377,21 +141,20 @@ async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Pro
             )
           : undefined,
       ].filter(Boolean))
-      await buildClassicSW(
+      await rolldown!.buildClassicSW(
         rootDir,
         sw,
         swTemp,
         inline,
         sourcemap,
         define,
-        workboxRegex,
         filePaths,
         options.classicWorkboxRuntimeCompatible === true,
       )
     }
     else {
       await fs.writeFile(path.resolve(rootDir, swTemp), chunks.swCode, 'utf8')
-      await buildESMSW(
+      await rolldown.buildModuleSW(
         rootDir,
         sw,
         swTemp,

--- a/packages/workbox/build/src/utils/build-generate-sw.ts
+++ b/packages/workbox/build/src/utils/build-generate-sw.ts
@@ -155,6 +155,7 @@ async function buildClassicSW(
         jsdoc: false,
         annotation: false,
       },
+      hashCharacters: classicWorkboxRuntimeCompatible ? 'hex' : undefined,
       chunkFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
       assetFileNames: '[name]-[hash].[ext]',
       entryFileNames: inline ? swName : `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`,
@@ -366,7 +367,14 @@ async function buildAssets<T extends SWType>(options: GenerateSWOptions<T>): Pro
       await Promise.all([
         fs.writeFile(path.resolve(rootDir, swTemp), chunks.swCode, 'utf8'),
         chunks.workbox
-          ? fs.writeFile(path.resolve(rootDir, 'workbox-classic.js'), chunks.workbox, 'utf8')
+          ? fs.writeFile(
+              path.resolve(
+                rootDir,
+                `workbox${options.classicWorkboxRuntimeCompatible ? '' : '-classic'}.js`,
+              ),
+              chunks.workbox,
+              'utf8',
+            )
           : undefined,
       ].filter(Boolean))
       await buildClassicSW(

--- a/packages/workbox/build/src/utils/generate-manifest-entries.ts
+++ b/packages/workbox/build/src/utils/generate-manifest-entries.ts
@@ -1,4 +1,4 @@
-import type { GenerateSWOptions, GetManifestResult, InjectManifestOptions, ManifestEntry } from '../types'
+import type { GenerateSWOptions, GetManifestResult, InjectManifestOptions, ManifestEntry, SWType } from '../types'
 import type { InternalManifestEntry } from './types'
 import { createHash } from 'node:crypto'
 import { readFile, stat } from 'node:fs/promises'
@@ -9,7 +9,8 @@ import { checkMaximumFileSizeToCacheExceeded } from './log'
 import { migrateGlobsToPicomatch } from './migrate-globs-to-picomatch'
 
 export async function generateManifestEntries(
-  options: GenerateSWOptions | InjectManifestOptions,
+  globDirectory: string,
+  options: GenerateSWOptions<SWType> | InjectManifestOptions,
 ): Promise<GetManifestResult> {
   if (!options.globDirectory) {
     return {
@@ -28,18 +29,12 @@ export async function generateManifestEntries(
     globIgnores,
   })
 
-  // Make sure we leave swDest out of the precache manifest.
-  // todo: add swDest here to ignores
-
-  // If we create an extra external runtime file, ignore that, too.
-  // See https://rollupjs.org/guide/en/#outputchunkfilenames for naming.
-  // todo: add glob here for 'workbox-*.js' here to ignores (when !options.inlineWorkboxRuntime) => can be done from outside
-
   const assets = await glob(patterns, {
-    cwd: options.globDirectory,
+    cwd: globDirectory,
     ignore,
     onlyFiles: true,
     absolute: false,
+    expandDirectories: false,
     followSymbolicLinks: options.globFollow,
   })
 
@@ -47,7 +42,7 @@ export async function generateManifestEntries(
   const maxFileSizeExceeded: (ManifestEntry & { size: number })[] = []
 
   let manifestEntries: (ManifestEntry & { size: number })[] = []
-  for await (const manifest of hashManifestEntries(assets, options)) {
+  for await (const manifest of hashManifestEntries(globDirectory, assets)) {
     if (manifest.size > maxFileSize) {
       maxFileSizeExceeded.push(manifest)
     }
@@ -89,11 +84,11 @@ export async function generateManifestEntries(
 }
 
 async function* hashManifestEntries(
+  globDirectory: string,
   assets: string[],
-  options: GenerateSWOptions,
 ): AsyncGenerator<InternalManifestEntry, undefined, void> {
   for (const asset of assets) {
-    const filePath = resolve(options.globDirectory!, asset)
+    const filePath = resolve(globDirectory!, asset)
     const stats = await stat(filePath)
     const revision = createHash('md5').update(await readFile(filePath)).digest('hex')
     yield { url: asset, revision, size: stats.size }

--- a/packages/workbox/build/src/utils/paths.ts
+++ b/packages/workbox/build/src/utils/paths.ts
@@ -1,3 +1,0 @@
-export function normalizePath(baseDirectory: string, path: string) {
-
-}

--- a/packages/workbox/build/src/utils/prepare-sw-code.ts
+++ b/packages/workbox/build/src/utils/prepare-sw-code.ts
@@ -1,19 +1,54 @@
+import type { ImportItemInput } from 'magicast'
 import type { GenerateSWOptions, GetManifestResult, SWType } from '../types'
 import { builders, generateCode, parseExpression, parseModule } from 'magicast'
 import serialize from 'serialize-javascript'
 import { generateManifestEntries } from './generate-manifest-entries'
 
-export interface InternalGetManifestResult extends GetManifestResult {
+export interface ChunksInfo {
   swCode: string
+  workbox?: string
+}
+
+export type ChunksInfoData<T extends SWType> = T extends 'classic'
+  ? ChunksInfo
+  : T extends 'module'
+    ? ChunksInfo
+    : {
+        classic: ChunksInfo
+        module: ChunksInfo
+      }
+
+export interface InternalGetManifestResult<T extends SWType> {
+  manifestEntries: GetManifestResult
+  chunks: ChunksInfoData<T>
 }
 
 export async function prepareSWCode<T extends SWType>(
+  globDirectory: string,
   options: GenerateSWOptions<T>,
-): Promise<InternalGetManifestResult> {
-  const swModule = parseModule('')
+): Promise<InternalGetManifestResult<T>> {
+  const manifestEntries = await generateManifestEntries(globDirectory, options)
 
-  const manifestEntries = await generateManifestEntries(options)
+  const chunks = options.swType === 'classic-and-module'
+    ? {
+        classic: {
+          swCode: '',
+        },
+        module: {
+          swCode: '',
+        },
+      } as ChunksInfoData<T>
+    : {
+        swCode: '',
+      } as ChunksInfoData<T>
 
+  prepareWorkboxRuntime(globDirectory, options, manifestEntries, chunks)
+
+  return {
+    manifestEntries,
+    chunks,
+  } as InternalGetManifestResult<T>
+  /*
   const strategyImports = new Set<string>()
   if (options.runtimeCaching) {
     for (const entry of options.runtimeCaching) {
@@ -141,25 +176,33 @@ export async function prepareSWCode<T extends SWType>(
     swCode.push('self.__WB_DISABLE_DEV_LOGS = true;')
   }
 
-  const importsCode = generateCode(swModule.imports).code
+  const _importsCode = generateCode(swModule.imports).code
 
-  return Object.assign({}, manifestEntries, {
-    swCode: `${importsCode}\n\n${swCode.join('\n')}`,
-  })
+  // return Object.assign({}, manifestEntries, {
+  //   swCode: `${importsCode}\n\n${swCode.join('\n')}`,
+  // }) */
 }
 
-function capitalize(s: string, sanitize = false) {
+export function camelize(str: string): string {
+  return str.replace(/-([a-z0-9])/g, g => g[1].toUpperCase())
+}
+
+function capitalize(s: string, sanitize = false): string {
   const value = s.charAt(0).toUpperCase() + s.slice(1)
   return sanitize ? value.replace(/['"]/g, '') : value
 }
 
 function getRuntimeCachingEntries<T extends SWType>(
+  classic: boolean,
+  workboxMap: Map<string, string>,
   options: GenerateSWOptions<T>,
 ): string[] {
   const entries: string[] = []
   if (!options.runtimeCaching) {
     return entries
   }
+
+  const prefix = createNamePrefix(workboxMap, () => classic)
 
   for (const entry of options.runtimeCaching) {
     let handlerNode: any
@@ -169,8 +212,8 @@ function getRuntimeCachingEntries<T extends SWType>(
 
       const args = entry.options ? [parseExpression(serialize(entry.options, { unsafe: true }))] : undefined
       handlerNode = args && args.length > 0
-        ? builders.newExpression(strategyName, ...args)
-        : builders.newExpression(strategyName)
+        ? builders.newExpression(prefix(strategyName), ...args)
+        : builders.newExpression(prefix(strategyName))
     }
     else {
       handlerNode = parseExpression(serialize(entry.handler, { unsafe: true }))
@@ -194,7 +237,7 @@ function getRuntimeCachingEntries<T extends SWType>(
     }
 
     const routeCallNode = builders.functionCall(
-      'registerRoute',
+      prefix('registerRoute'),
       ...routeCallArgs,
     )
 
@@ -202,4 +245,277 @@ function getRuntimeCachingEntries<T extends SWType>(
   }
 
   return entries
+}
+
+function addImportMap(
+  map: Map<string, string[]>,
+  workboxMap: Map<string, string>,
+  item: ImportItemInput,
+) {
+  const from = item.from
+  let entries = map.get(from)
+  if (!entries) {
+    entries = []
+    map.set(from, entries)
+  }
+  // classic only:
+  const fromKey = camelize(from.split('/').pop()!)
+  // self.workbox.xxx = xxx where xxx is the subpackage export name (import * as xxx from '.../xxx')
+  workboxMap.set(from, fromKey)
+  // precacheAndRoute comes from workbox-swkit/precaching => self.workbox.precaching.precacheAndRoute
+  workboxMap.set(item.imported, fromKey)
+  // esm: no action required here
+  entries.push(item.imported)
+}
+
+function isDualBuild(chunksInfoData: ChunksInfoData<SWType>): chunksInfoData is ChunksInfoData<'classic-and-module'> {
+  return 'classic' in chunksInfoData && 'module' in chunksInfoData
+}
+
+function createNamePrefix(workboxMap: Map<string, string>, classic: () => boolean) {
+  return (name: string): string => {
+    return classic() ? `workbox.${workboxMap.get(name)}.${name}` : name
+  }
+}
+
+function internalPrepareSWCode<T extends SWType>(
+  classic: boolean,
+  workboxMap: Map<string, string>,
+  options: GenerateSWOptions<T>,
+  manifestEntries: GetManifestResult,
+): string {
+  const prefix = createNamePrefix(workboxMap, () => classic)
+
+  const swCode: string[] = []
+
+  if (options.navigationPreload) {
+    swCode.push(`${prefix('enable')}();`)
+  }
+
+  if (options.cacheId) {
+    const call = builders.functionCall(prefix('setCacheNameDetails'), { prefix: options.cacheId })
+    swCode.push(generateCode(call).code)
+  }
+
+  if (options.skipWaiting) {
+    swCode.push('self.skipWaiting();')
+  }
+  else {
+    swCode.push(`self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});`)
+  }
+
+  if (manifestEntries.manifestEntries.length > 0) {
+    const precacheOptions: any = {}
+    if (options.directoryIndex) {
+      precacheOptions.directoryIndex = options.directoryIndex
+    }
+    if (options.ignoreURLParametersMatching) {
+      precacheOptions.ignoreURLParametersMatching = options.ignoreURLParametersMatching
+    }
+    if (options.cleanURLs) {
+      precacheOptions.cleanURLs = options.cleanURLs
+    }
+    if (options.urlManipulation) {
+      precacheOptions.urlManipulation = parseExpression(serialize(options.urlManipulation, { unsafe: true }))
+    }
+
+    const precacheAndRoute = Object.keys(precacheOptions).length > 0
+      ? builders.functionCall(prefix('precacheAndRoute'), manifestEntries.manifestEntries, precacheOptions)
+      : builders.functionCall(prefix('precacheAndRoute'), manifestEntries.manifestEntries)
+
+    swCode.push(generateCode(precacheAndRoute).code)
+  }
+
+  if (options.cleanupOutdatedCaches) {
+    swCode.push(`${prefix('cleanupOutdatedCaches')}()`)
+  }
+
+  if (options.navigateFallback) {
+    const handler = builders.functionCall(prefix('createHandlerBoundToURL'), options.navigateFallback)
+    let newOptions: any
+    if (options.navigateFallbackAllowlist || options.navigateFallbackDenylist) {
+      newOptions = {}
+      if (options.navigateFallbackAllowlist) {
+        newOptions.allowlist = options.navigateFallbackAllowlist
+      }
+      if (options.navigateFallbackDenylist) {
+        newOptions.denylist = options.navigateFallbackDenylist
+      }
+    }
+    const navigationRoute = newOptions
+      ? builders.newExpression(prefix('NavigationRoute'), handler, newOptions)
+      : builders.newExpression(prefix('NavigationRoute'), handler)
+    const registerRoute = builders.functionCall(prefix('registerRoute'), navigationRoute)
+    swCode.push(generateCode(registerRoute).code)
+  }
+
+  if (options.runtimeCaching) {
+    swCode.push(...getRuntimeCachingEntries(classic, workboxMap, options))
+  }
+
+  if (options.disableDevLogs) {
+    swCode.push('self.__WB_DISABLE_DEV_LOGS = true;')
+  }
+
+  return swCode.join('\n')
+}
+
+function prepareWorkboxModule(
+  classic: boolean,
+  map: Map<string, string[]>,
+  workboxMap: Map<string, string>,
+  inline: boolean,
+) {
+  const module = parseModule('')
+  let code: string
+  if (classic) {
+    code = ''
+    for (const key of map.keys()) {
+      code += `${code ? '\n' : ''}import * as ${workboxMap.get(key)} from "${key}";`
+    }
+  }
+  else {
+    for (const [key, imports] of map.entries()) {
+      for (const imported of imports) {
+        module.imports.$append({ from: key, imported })
+      }
+    }
+    code = generateCode(module, { format: {
+      tabWidth: 2,
+      useTabs: false,
+      quote: 'single',
+      trailingComma: false,
+      arrayBracketSpacing: false,
+      objectCurlySpacing: false,
+      arrowParensAlways: true,
+      useSemi: true,
+    } }).code
+  }
+
+  if (classic) {
+    return `${code}
+self.workbox=self.workbox||{};
+${Array.from(map.keys()).map(k => `self.workbox.${workboxMap.get(k)} = ${workboxMap.get(k)};`).join('\n')}    
+`
+  }
+  else {
+    if (inline) {
+      return code
+    }
+    const exports: string[] = []
+    for (const [_, imports] of map.entries()) {
+      for (const imported of imports) {
+        exports.push(imported)
+      }
+    }
+    return `${code}
+    
+export {${exports.join(', ')}}
+`
+  }
+}
+
+function prepareWorkboxRuntime<T extends SWType>(
+  globDirectory: string,
+  options: GenerateSWOptions<T>,
+  manifestEntries: GetManifestResult,
+  chunksInfoData: ChunksInfoData<T>,
+) {
+  const map = new Map<string, string[]>()
+  const workboxMap = new Map<string, string>()
+  const strategyImports = new Set<string>()
+  if (options.runtimeCaching) {
+    for (const entry of options.runtimeCaching) {
+      if (typeof entry.handler === 'string') {
+        strategyImports.add(capitalize(entry.handler))
+      }
+    }
+  }
+
+  if (manifestEntries.manifestEntries.length > 0) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'precacheAndRoute' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'precacheAndRoute' })
+  }
+
+  if (options.navigationPreload) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/navigation-preload', imported: 'enable' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/navigation-preload', imported: 'enable' })
+  }
+
+  if (options.cacheId) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/core', imported: 'setCacheNameDetails' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/core', imported: 'setCacheNameDetails' })
+  }
+
+  if (options.skipWaiting) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/core', imported: 'skipWaiting' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/core', imported: 'skipWaiting' })
+  }
+  if (options.clientsClaim) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/core', imported: 'clientsClaim' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/core', imported: 'clientsClaim' })
+  }
+  if (options.cleanupOutdatedCaches) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'cleanupOutdatedCaches' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'cleanupOutdatedCaches' })
+  }
+
+  const needsRegisterRoute = options.runtimeCaching?.length || options.navigateFallback
+  if (needsRegisterRoute) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/routing', imported: 'registerRoute' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/routing', imported: 'registerRoute' })
+  }
+
+  if (options.navigateFallback) {
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/routing', imported: 'NavigationRoute' })
+    addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'createHandlerBoundToURL' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/routing', imported: 'NavigationRoute' })
+    // workboxModule.imports.$append({ from: '@composable-vite-pwa/workbox-swkit/precaching', imported: 'createHandlerBoundToURL' })
+  }
+
+  if (options.runtimeCaching?.length) {
+    if (strategyImports.size > 0) {
+      for (const strategyImport of strategyImports) {
+        addImportMap(map, workboxMap, { from: '@composable-vite-pwa/workbox-swkit/strategies', imported: strategyImport })
+        // swModule.imports.$append({
+        //   from: '@composable-vite-pwa/workbox-swkit/strategies',
+        //   imported: strategyImport,
+        // })
+      }
+    }
+  }
+
+  const inlineWorkboxRuntime = options.inlineWorkboxRuntime === true
+
+  if (isDualBuild(chunksInfoData)) {
+    const workboxClassicCode = prepareWorkboxModule(true, map, workboxMap, inlineWorkboxRuntime)
+    const swClassicCode = internalPrepareSWCode(true, workboxMap, options, manifestEntries)
+    const workboxModuleCode = prepareWorkboxModule(false, map, workboxMap, inlineWorkboxRuntime)
+    const swModuleCode = internalPrepareSWCode(false, workboxMap, options, manifestEntries)
+
+    chunksInfoData.module.swCode = `${workboxModuleCode}\n${swModuleCode}`
+    if (inlineWorkboxRuntime) {
+      chunksInfoData.classic.swCode = `${workboxClassicCode}\n${swClassicCode}`
+    }
+    else {
+      chunksInfoData.classic.workbox = workboxClassicCode
+      chunksInfoData.classic.swCode = `importScripts("./workbox-classic.js");\n${swClassicCode}`
+    }
+  }
+  else {
+    const classic = options.swType === 'classic'
+    const workboxCode = prepareWorkboxModule(classic, map, workboxMap, inlineWorkboxRuntime)
+    const swCode = internalPrepareSWCode(classic, workboxMap, options, manifestEntries)
+    if (inlineWorkboxRuntime || options.swType === 'module') {
+      chunksInfoData.swCode = `${workboxCode}\n${swCode}`
+    }
+    else {
+      chunksInfoData.workbox = workboxCode
+      chunksInfoData.swCode = `importScripts("./workbox-classic.js");\n${swCode}`
+    }
+  }
 }

--- a/packages/workbox/build/src/utils/prepare-sw-code.ts
+++ b/packages/workbox/build/src/utils/prepare-sw-code.ts
@@ -42,7 +42,7 @@ export async function prepareSWCode<T extends SWType>(
         swCode: '',
       } as ChunksInfoData<T>
 
-  prepareWorkboxRuntime(globDirectory, options, manifestEntries, chunks)
+  prepareWorkboxRuntime(options, manifestEntries, chunks)
 
   return {
     manifestEntries,
@@ -420,7 +420,6 @@ export {${exports.join(', ')}}
 }
 
 function prepareWorkboxRuntime<T extends SWType>(
-  globDirectory: string,
   options: GenerateSWOptions<T>,
   manifestEntries: GetManifestResult,
   chunksInfoData: ChunksInfoData<T>,
@@ -515,7 +514,7 @@ function prepareWorkboxRuntime<T extends SWType>(
     }
     else {
       chunksInfoData.workbox = workboxCode
-      chunksInfoData.swCode = `importScripts("./workbox-classic.js");\n${swCode}`
+      chunksInfoData.swCode = `importScripts("./workbox${options.classicWorkboxRuntimeCompatible ? '' : '-classic'}.js");\n${swCode}`
     }
   }
 }

--- a/packages/workbox/build/src/utils/rolldown-build.ts
+++ b/packages/workbox/build/src/utils/rolldown-build.ts
@@ -1,0 +1,244 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import MagicString from 'magic-string'
+import { rolldown } from 'rolldown'
+
+export async function buildClassicSW(
+  rootDir: string,
+  swName: string,
+  tempSwName: string,
+  inline: boolean,
+  sourcemap: boolean,
+  define: import('rolldown').TransformOptions['define'],
+  filePaths: string[],
+  classicWorkboxRuntimeCompatible: boolean,
+  workboxClassicFileForSourceMap?: string,
+) {
+  const workboxAssetName = `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}-[hash].js`
+  const workboxChunkName = `workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}`
+  const workboxFile = path.resolve(rootDir, `${workboxChunkName}.js`)
+  const instance = await rolldown({
+    input: inline ? tempSwName : `${workboxChunkName}.js`,
+    platform: 'browser',
+    transform: { define },
+  })
+  const { output } = await instance.write({
+    sourcemap,
+    comments: {
+      legal: true,
+      jsdoc: false,
+      annotation: false,
+    },
+    dir: rootDir,
+    format: 'iife',
+    cleanDir: false,
+    hashCharacters: classicWorkboxRuntimeCompatible ? 'hex' : undefined,
+    chunkFileNames: inline ? swName : workboxAssetName,
+    assetFileNames: '[name]-[hash].[ext]',
+    entryFileNames: inline ? swName : workboxAssetName,
+    codeSplitting: false,
+  })
+  for (const chunk of output) {
+    filePaths.push(path.resolve(rootDir, chunk.fileName))
+  }
+  const tempSWFile = path.resolve(rootDir, tempSwName)
+  if (inline) {
+    await Promise.all([
+      fs.rm(tempSWFile, { force: true }),
+      fixSourceMaps(
+        sourcemap,
+        swName,
+        path.resolve(rootDir, swName),
+        classicWorkboxRuntimeCompatible,
+        workboxClassicFileForSourceMap,
+        workboxClassicFileForSourceMap && sourcemap
+          ? {
+              tempName: `${workboxChunkName}.js`,
+              name: workboxClassicFileForSourceMap!,
+              file: path.resolve(rootDir, workboxClassicFileForSourceMap!),
+            }
+          : undefined,
+      ),
+    ])
+    return
+  }
+
+  const workboxClassicFile = output.find(chunk => chunk.name === workboxChunkName)?.fileName
+
+  if (!workboxClassicFile) {
+    await Promise.all([
+      fs.rm(workboxFile, { force: true }),
+      fs.rm(tempSWFile, { force: true }),
+    ])
+    throw new Error(`${path.relative(
+      rootDir,
+      workboxFile,
+    ).replace(
+      '.js',
+      '',
+    ).replace(
+      /\\/g,
+      '/',
+    )}-<hash>.js asset not found!`)
+  }
+
+  await Promise.all([
+    fs.rm(workboxFile, { force: true }),
+    buildClassicSW(
+      rootDir,
+      swName,
+      tempSwName,
+      true,
+      sourcemap,
+      define,
+      filePaths,
+      classicWorkboxRuntimeCompatible,
+      workboxClassicFile,
+    ),
+  ])
+}
+
+export async function buildModuleSW(
+  rootDir: string,
+  swName: string,
+  tempSwName: string,
+  inline: boolean,
+  sourcemap: boolean,
+  define: import('rolldown').TransformOptions['define'],
+  workboxRegex: RegExp[],
+  filePaths: string[],
+) {
+  const instance = await rolldown({
+    input: tempSwName,
+    treeshake: true,
+    platform: 'browser',
+    transform: { define },
+  })
+  const swChunkName = tempSwName.replace('.js', '')
+  const { output } = await instance.write({
+    sourcemap,
+    comments: {
+      legal: true,
+      jsdoc: false,
+      annotation: false,
+    },
+    dir: rootDir,
+    format: 'esm',
+    cleanDir: false,
+    chunkFileNames: (chunk) => {
+      switch (chunk.name) {
+        case 'workbox-module':
+          return 'workbox-module-[hash].js'
+        case swChunkName:
+          return swName
+        default:
+          return '[name]-[hash].[ext]'
+      }
+    },
+    assetFileNames: '[name]-[hash].[ext]',
+    entryFileNames: (chunk) => {
+      switch (chunk.name) {
+        case 'workbox-module':
+          return 'workbox-module-[hash].js'
+        case swChunkName:
+          return swName
+        default:
+          return '[name]-[hash].js'
+      }
+    },
+    codeSplitting: inline
+      ? false
+      : {
+          groups: [
+            {
+              minSize: 0,
+              name: (moduleId) => {
+                return workboxRegex.some(r => r.test(moduleId)) ? 'workbox-module' : undefined
+              },
+            },
+          ],
+        },
+  })
+  for (const chunk of output) {
+    filePaths.push(path.resolve(rootDir, chunk.fileName))
+  }
+  await fs.rm(path.resolve(rootDir, tempSwName), { force: true })
+  if (inline) {
+    return
+  }
+  const workboxModuleFile = output.find(chunk => chunk.name === 'workbox-module')?.fileName
+  await fixSourceMaps(
+    sourcemap,
+    swName,
+    path.resolve(rootDir, swName),
+    false,
+    undefined,
+    workboxModuleFile && sourcemap
+      ? {
+          tempName: 'workbox-module.js',
+          name: workboxModuleFile,
+          file: path.resolve(rootDir, workboxModuleFile),
+        }
+      : undefined,
+  )
+}
+
+async function fixSourceMaps(
+  sourcemap: boolean,
+  swName: string,
+  swFile: string,
+  classicWorkboxRuntimeCompatible: boolean,
+  classicReplacementName?: string,
+  workbox?: {
+    tempName: string
+    name: string
+    file: string
+  },
+) {
+  await Promise.all([
+    fs.readFile(swFile, 'utf-8').then((code) => {
+      const s = new MagicString(code)
+      s.replace(
+        `//#region ${swName.replace('.js', '.temp.js')}`,
+        `//#region ${swName}`,
+      )
+      if (classicReplacementName) {
+        s.replace(
+          `importScripts("./workbox${classicWorkboxRuntimeCompatible ? '' : '-classic'}.js")`,
+          `importScripts("./${classicReplacementName}")`,
+        )
+      }
+      return fs.writeFile(swFile, s.toString(), 'utf-8')
+    }),
+    sourcemap
+      ? fs.writeFile(
+          swFile.replace('.js', '.js.map'),
+          await fs.readFile(
+            swFile.replace('.js', '.js.map'),
+            'utf-8',
+          ).then((code) => {
+            return code.replace(
+              `"${swName.replace('.js', '.temp.js')}"`,
+              `"${swName}"`,
+            )
+          }),
+          'utf-8',
+        )
+      : undefined,
+    sourcemap && workbox
+      ? fs.writeFile(
+          workbox.file.replace('.js', '.js.map'),
+          await fs.readFile(
+            workbox.file.replace('.js', '.js.map'),
+            'utf-8',
+          ).then((code) => {
+            return code.replace(
+              `"${workbox.tempName}"`,
+              `"${workbox.name}"`,
+            )
+          }),
+          'utf-8',
+        )
+      : undefined,
+  ].filter(Boolean))
+}

--- a/packages/workbox/build/src/utils/types.ts
+++ b/packages/workbox/build/src/utils/types.ts
@@ -1,12 +1,3 @@
-import type { BuildResult, ManifestEntry, SWType } from '../types'
+import type { ManifestEntry } from '../types'
 
 export type InternalManifestEntry = ManifestEntry & { size: number }
-
-export type GenerateSWResult<T extends SWType> = T extends 'classic'
-  ? BuildResult
-  : T extends 'module'
-    ? BuildResult
-    : {
-        classic: BuildResult
-        module: BuildResult
-      }

--- a/packages/workbox/build/src/validation/async-generate-sw.ts
+++ b/packages/workbox/build/src/validation/async-generate-sw.ts
@@ -16,6 +16,15 @@ export const AsyncGenerateSWOptionsSchema = v.pipeAsync(
       'classic-and-module',
     ]), 'classic'),
     /**
+     * When using `classic` and splitting workbox runtime (inlineWorkboxRuntime set to false), this flag controls the
+     * name of the `workbox-**.js` chunk:
+     * - when true, workbox will generate the same old asset name `workbox-<hex>.js` (using `hex` instead new Rolldown naming)
+     * - when false, workbox will generate `classic-workbox-<rolldown-hash>.js`.
+     *
+     * @default true
+     */
+    classicWorkboxRuntimeCompatible: v.optionalAsync(v.boolean(), true),
+    /**
      * The [targets](https://babeljs.io/docs/en/babel-preset-env#targets) to pass to `babel-preset-env` when transpiling the service worker bundle.
      */
     babelPresetEnvTargets: v.optionalAsync(v.arrayAsync(v.string()), ['chrome >= 56']),

--- a/packages/workbox/build/src/validation/validation-helper.ts
+++ b/packages/workbox/build/src/validation/validation-helper.ts
@@ -1,6 +1,6 @@
 // import type { ArrayExpression, Program } from '@babel/types'
 import type { BaseIssue, BaseSchemaAsync, InferOutput, IssuePathItem } from 'valibot'
-import type { GenerateSWOptions, InjectManifestOptions } from '../types'
+import type { GenerateSWOptions, InjectManifestOptions, SWType } from '../types'
 import { getDotPath, safeParseAsync } from 'valibot'
 import { AsyncGenerateSWOptionsSchema } from './async-generate-sw'
 import { AsyncInjectManifestOptionsSchema } from './async-inject-manifest'
@@ -146,7 +146,7 @@ function _sanitizeMagicastOptions(options: any): any {
   return sanitized
 }
 
-export async function validateGenerateSW(options: GenerateSWOptions): Promise<InferOutput<typeof AsyncGenerateSWOptionsSchema>> {
+export async function validateGenerateSW<T extends SWType>(options: GenerateSWOptions<T>): Promise<InferOutput<typeof AsyncGenerateSWOptionsSchema>> {
   return await validateAsync(AsyncGenerateSWOptionsSchema, options, 'generateSW')
 }
 

--- a/packages/workbox/build/src/validation/validation-options.ts
+++ b/packages/workbox/build/src/validation/validation-options.ts
@@ -1,4 +1,4 @@
-import type { GenerateSWOptions } from '../types'
+import type { GenerateSWOptions, SWType } from '../types'
 import { errors } from './errors'
 
 const DEFAULT_EXCLUDE_VALUE = [/\.map$/, /^manifest.*\.js$/]
@@ -10,7 +10,7 @@ export class WorkboxConfigError extends Error {
   }
 }
 export function ensureValidNavigationPreloadConfig(
-  options: GenerateSWOptions,
+  options: GenerateSWOptions<SWType>,
 ): void {
   if (
     options.navigationPreload
@@ -22,7 +22,7 @@ export function ensureValidNavigationPreloadConfig(
 }
 
 export function ensureValidCacheExpiration(
-  options: GenerateSWOptions,
+  options: GenerateSWOptions<SWType>,
 ): void {
   for (const runtimeCaching of options.runtimeCaching || []) {
     if (
@@ -35,7 +35,7 @@ export function ensureValidCacheExpiration(
 }
 
 export function ensureValidRuntimeCachingOrGlobDirectory(
-  options: GenerateSWOptions,
+  options: GenerateSWOptions<SWType>,
 ): void {
   if (
     !options.globDirectory

--- a/packages/workbox/build/tsdown.config.mts
+++ b/packages/workbox/build/tsdown.config.mts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'tsdown'
-import { workboxBanner as banner, cleanupJSTypes, fixTypesVersion } from '../../../tsdown-helper'
+import { attw, workboxBanner as banner, cleanupJSTypes, fixTypesVersion, publint } from '../../../tsdown-helper'
 
 const require = createRequire(import.meta.url)
 const _packageJson = require('./package.json')
@@ -12,6 +12,8 @@ export default defineConfig({
   entry: './src/{config,index,types,generate-sw,get-manifest,inject-manifest}.ts',
   platform: 'node',
   banner,
+  attw,
+  publint,
   exports: fixTypesVersion,
   hooks: {
     'build:done': async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,16 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  babel:
-    '@babel/core':
-      specifier: ^7.29.0
-      version: 7.29.0
-    '@babel/plugin-transform-dynamic-import':
-      specifier: ^7.27.1
-      version: 7.27.1
-    '@babel/plugin-transform-modules-amd':
-      specifier: ^7.27.1
-      version: 7.27.1
   build:
     tsdown:
       specifier: ^0.21.10
@@ -109,6 +99,12 @@ catalogs:
     publint:
       specifier: ^0.3.18
       version: 0.3.18
+    rolldown:
+      specifier: ^1.0.0-rc.17
+      version: 1.0.0-rc.17
+    semver:
+      specifier: ^7.7.4
+      version: 7.7.4
     serialize-javascript:
       specifier: ^7.0.5
       version: 7.0.5
@@ -129,9 +125,6 @@ catalogs:
     vue:
       specifier: ^3.5.31
       version: 3.5.33
-
-overrides:
-  semver: ^7.7.4
 
 importers:
 
@@ -186,7 +179,7 @@ importers:
         specifier: catalog:react
         version: 19.2.5
       semver:
-        specifier: ^7.7.4
+        specifier: catalog:utils
         version: 7.7.4
       solid-js:
         specifier: catalog:solid-js
@@ -266,15 +259,6 @@ importers:
 
   packages/workbox/build:
     dependencies:
-      '@babel/core':
-        specifier: catalog:babel
-        version: 7.29.0
-      '@babel/plugin-transform-dynamic-import':
-        specifier: catalog:babel
-        version: 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd':
-        specifier: catalog:babel
-        version: 7.27.1(@babel/core@7.29.0)
       '@composable-vite-pwa/workbox-swkit':
         specifier: workspace:*
         version: link:../swkit
@@ -312,6 +296,9 @@ importers:
       '@types/serialize-javascript':
         specifier: catalog:types
         version: 5.0.4
+      rolldown:
+        specifier: catalog:utils
+        version: 1.0.0-rc.17
 
   packages/workbox/cli:
     dependencies:
@@ -418,47 +405,9 @@ packages:
     resolution: {integrity: sha512-Izvir8iIoU+X4SKtDAa5kpb+9cpifclzsbA8x/AZY0k0gIfXYQ1fa1B6Epfe6vNA2YfDX8VtrZFgvnXB6aPEoQ==}
     engines: {node: '>=18'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@8.0.0-rc.3':
     resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -476,14 +425,6 @@ packages:
     resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -493,26 +434,6 @@ packages:
     resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  '@babel/plugin-transform-dynamic-import@7.27.1':
-    resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-amd@7.27.1':
-    resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -1828,10 +1749,6 @@ packages:
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1928,9 +1845,6 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
   jsdoc-type-pratt-parser@7.1.1:
     resolution: {integrity: sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==}
     engines: {node: '>=20.0.0'}
@@ -1952,11 +1866,6 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   jsonc-eslint-parser@3.1.0:
     resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
@@ -2066,9 +1975,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2859,9 +2765,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yaml-eslint-parser@2.0.0:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2983,42 +2886,6 @@ snapshots:
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.0': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@8.0.0-rc.3':
     dependencies:
       '@babel/parser': 8.0.0-rc.3
@@ -3028,34 +2895,6 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
-      lru-cache: 5.1.1
-      semver: 7.7.4
-
-  '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@8.0.0-rc.3': {}
@@ -3064,13 +2903,6 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.29.2':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
@@ -3078,37 +2910,6 @@ snapshots:
   '@babel/parser@8.0.0-rc.3':
     dependencies:
       '@babel/types': 8.0.0-rc.3
-
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/template@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -4387,8 +4188,6 @@ snapshots:
 
   fzf@0.5.2: {}
 
-  gensync@1.0.0-beta.2: {}
-
   get-caller-file@2.0.5: {}
 
   get-tsconfig@4.14.0:
@@ -4453,8 +4252,6 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-tokens@4.0.0: {}
-
   jsdoc-type-pratt-parser@7.1.1: {}
 
   jsdoc-type-pratt-parser@7.2.0: {}
@@ -4466,8 +4263,6 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@2.2.3: {}
 
   jsonc-eslint-parser@3.1.0:
     dependencies:
@@ -4554,10 +4349,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -5557,8 +5348,6 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   y18n@5.0.8: {}
-
-  yallist@3.1.1: {}
 
   yaml-eslint-parser@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,19 +20,12 @@ strictPeerDependencies: false
 
 trustPolicy: no-downgrade
 
-overrides:
-  semver: ^7.7.4
-
 packages:
   - examples/**
   - packages/core/**
   - packages/workbox/**
 
 catalogs:
-  babel:
-    "@babel/core": ^7.29.0
-    "@babel/plugin-transform-modules-amd": ^7.27.1
-    "@babel/plugin-transform-dynamic-import": ^7.27.1
   build:
     tsdown: ^0.21.10
   eslint:
@@ -71,6 +64,7 @@ catalogs:
     pkg-types: ^2.3.0
     proper-tags: ^2.0.2
     publint: ^0.3.18
+    rolldown: ^1.0.0-rc.17
     semver: ^7.7.4
     serialize-javascript: ^7.0.5
     taze: ^19.10.0


### PR DESCRIPTION
I need to:
- replace tsdown with rolldown: tsdown is huge (rolldown-plugin-dts requires babel types, 32% the size of tsdown 🤦‍♂️ ), babel is everywhere
- use rolldown native magic string instead magic-string: will go to main directly and maybe using magic-string
- add injectManifest logic with native magic string: will go to main directly

<details>
<summary>screenshots</summary>

<img width="369" height="293" alt="dual service worker build for classic and esm" src="https://github.com/user-attachments/assets/a57c8ea3-0bad-44a9-89ab-8f11fe997d8e" />

<img width="1363" height="548" alt="npm graph" src="https://github.com/user-attachments/assets/e9b99d1f-cbfe-4d02-8c5a-1965e5dbe125" />

</details>