### PR TITLE
test: skip webpack/rspack tests in watch mode

### DIFF
--- a/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
+++ b/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
@@ -138,6 +138,8 @@ function runRspack(config: rspack.Configuration): Promise<rspack.Stats> {
   })
 }
 
+const isWatchMode = process.env.VITEST_MODE === 'WATCH';
+
 export const testWebpack = base.extend<{
   sandbox: {
     root: string
@@ -148,7 +150,7 @@ export const testWebpack = base.extend<{
   sandbox: async ({}, use) => {
     await createFixture('webpack', use)
   },
-})
+}).skipIf(isWatchMode)
 
 export const testRspack = base.extend<{
   sandbox: {
@@ -160,7 +162,7 @@ export const testRspack = base.extend<{
   sandbox: async ({}, use) => {
     await createFixture('rspack', use)
   },
-})
+}).skipIf(isWatchMode)
 
 describe('webpack/rspack WorkboxPlugin', () => {
   testWebpack('runs build-sw with webpack compiler context and relative paths', async ({ sandbox }) => {


### PR DESCRIPTION
## Summary
The heavy webpack/rspack integration tests create temporary fixtures and cause infinite reruns when Vitest runs in watch mode. This PR skips them in watch mode using `.skipIf(process.env.VITEST_MODE === 'WATCH')` on the `testWebpack` and `testRspack` fixtures.

## Changes
- Added `const isWatchMode = process.env.VITEST_MODE === 'WATCH'`
- Applied `.skipIf(isWatchMode)` to both fixture exports
- No other changes

## Testing
- Single run (CI mode):  
  `pnpm --filter @composable-vite-pwa/workbox-build test:ci webpack-rspack-plugins`  
  → all 3 tests pass ✅
- Watch mode:  
  `pnpm --filter @composable-vite-pwa/workbox-build test webpack-rspack-plugins --watch`  
  → tests skip instantly, no reruns ✅

## Related
- Original PR #9