### PR TITLE
fix(workbox-build): change sourcemap default from true to false

### DIFF
--- a/packages/workbox/build/src/types.ts
+++ b/packages/workbox/build/src/types.ts
@@ -421,7 +421,7 @@ export interface GeneratePartial<T extends SWType> {
    * - `inline`: The sourcemap will be appended to the output file as a data URL.
    * - `hidden`: A separate sourcemap file will be generated, but the link to the sourcemap (`//# sourceMappingURL` comment) will not be included in the output file.
    *
-   * @default true
+   * @default false
    */
   sourcemap?: boolean | 'hidden' | 'inline'
 }

--- a/packages/workbox/build/src/validation/async-build-sw.ts
+++ b/packages/workbox/build/src/validation/async-build-sw.ts
@@ -56,7 +56,7 @@ const BaseInjectManifestEntries = v.pipeAsync(
     minify: v.optional(v.boolean()),
     /**
      * Whether to create a sourcemap.
-     * @default true
+     * @default false
      */
     sourcemap: v.optional(
       v.union([
@@ -64,7 +64,7 @@ const BaseInjectManifestEntries = v.pipeAsync(
         v.literal('hidden'),
         v.literal('inline'),
       ]),
-      true,
+      false,
     ),
     /**
      * Custom chunks support.

--- a/packages/workbox/build/src/validation/async-generate-sw.ts
+++ b/packages/workbox/build/src/validation/async-generate-sw.ts
@@ -108,7 +108,7 @@ const BaseAsyncGenerateSWOptionsSchema = v.pipeAsync(
      * - `inline`: The sourcemap will be appended to the output file as a data URL.
      * - `hidden`: A separate sourcemap file will be generated, but the link to the sourcemap (`//# sourceMappingURL` comment) will not be included in the output file.
      *
-     * @default true
+     * @default false
      */
     sourcemap: v.optional(
       v.union([
@@ -116,7 +116,7 @@ const BaseAsyncGenerateSWOptionsSchema = v.pipeAsync(
         v.literal('hidden'),
         v.literal('inline'),
       ]),
-      true,
+      false,
     ),
     /**
      * The path and filename of the service worker file that will be created by the build process, relative to the current working directory. It must end in '.js'.


### PR DESCRIPTION
## Summary
As requested, this PR changes the default value of the `sourcemap` option from `true` to `false`. The validation schema and TypeScript types are now in sync.

## Changes
- **Valibot schema** (`async-build-sw.ts`, `async-generate-sw.ts`): changed default from `true` to `false`
- **TypeScript type** (`types.ts`): updated JSDoc `@default` to `false`

## Testing
- Ran `pnpm test:ci` – all tests pass ✅
- Verified manually that `sourcemap` now defaults to `false` in validation and types.

---

**Ready for review.**