### PR TITLE
test(workbox-build): add Vite and Rolldown build tests for buildSW

### DIFF
--- a/packages/workbox/build/test/vite-rolldown-build-sw.spec.ts
+++ b/packages/workbox/build/test/vite-rolldown-build-sw.spec.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { rolldown } from 'rolldown'
+import { build as viteBuild } from 'vite'
+import { it as base, describe, expect } from 'vitest'
+import { normalizePath } from '../src/build/builder/utils'
+import { buildSW as rolldownBuildSW } from '../src/build/rolldown/build-sw'
+import { buildSW as viteBuildSW } from '../src/build/vite/build-sw'
+
+const isWatchMode = process.env.VITEST_MODE === 'WATCH'
+
+const swCode = `self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+self.addEventListener('activate', () => {
+  console.log('SW activated');
+});
+self.addEventListener('fetch', (event) => {
+  console.log('Fetch:', event.request.url);
+});
+`
+
+async function createFixture(
+  swCode: string,
+  use: (paths: { root: string, dist: string }) => Promise<void>,
+) {
+  let root: string | undefined
+  try {
+    root = await fs.mkdtemp(path.resolve(process.cwd(), 'test', 'temp-fixtures', 'vite-pwa-'))
+    const src = path.resolve(root, 'src')
+    const dist = path.resolve(root, 'dist')
+    await fs.mkdir(src, { recursive: true })
+    await fs.writeFile(path.resolve(src, 'index.js'), 'console.log("PWA test");\n')
+    await fs.writeFile(path.resolve(src, 'sw.js'), swCode, 'utf-8')
+    await fs.writeFile(path.resolve(root, 'package.json'), '{}')
+    await use({ root, dist })
+  }
+  finally {
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+        .catch(err => console.error(`Failed to cleanup sandbox at ${root}:`, err))
+    }
+  }
+}
+
+export const testVite = base.extend<{ sandbox: { root: string, dist: string } }>({
+  // eslint-disable-next-line no-empty-pattern
+  sandbox: async ({}, use) => {
+    await createFixture(swCode, use)
+  },
+}).skipIf(isWatchMode)
+
+export const testRolldown = base.extend<{ sandbox: { root: string, dist: string } }>({
+  // eslint-disable-next-line no-empty-pattern
+  sandbox: async ({}, use) => {
+    await createFixture(swCode, use)
+  },
+}).skipIf(isWatchMode)
+
+describe('buildSW with Vite (modern)', () => {
+  testVite('generates a service worker after building the app', async ({ sandbox }) => {
+    const { root, dist } = sandbox
+    await viteBuild({
+      root,
+      build: { outDir: dist, rollupOptions: { input: path.resolve(root, 'src/index.js') } },
+      logLevel: 'silent',
+    })
+    const swSrc = normalizePath(path.resolve(root, 'src/sw.js'))
+    const swDest = normalizePath(path.resolve(dist, 'sw.js'))
+    const globDirectory = normalizePath(dist)
+    await viteBuildSW({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      inlineWorkboxRuntime: true,
+      sourcemap: false,
+      mode: 'production',
+      logLevel: 'silent',
+      bundlerLogLevel: { vite: 'silent' },
+    })
+    const swFilePromise = fs.readFile(swDest, 'utf8')
+    await expect(swFilePromise).resolves.not.toThrow()
+    const swContent = await swFilePromise
+    expect(swContent).toContain('self.addEventListener')
+    expect(swContent.length).toBeGreaterThan(0)
+  })
+})
+
+describe('buildSW with Rolldown (direct)', () => {
+  testRolldown('generates a service worker directly', async ({ sandbox }) => {
+    const { root, dist } = sandbox
+    const rolldownBuild = await rolldown({ input: path.resolve(root, 'src/index.js') })
+    await rolldownBuild.write({ dir: dist })
+    const swSrc = normalizePath(path.resolve(root, 'src/sw.js'))
+    const swDest = normalizePath(path.resolve(dist, 'sw.js'))
+    const globDirectory = normalizePath(dist)
+    await rolldownBuildSW({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      inlineWorkboxRuntime: true,
+      sourcemap: false,
+      mode: 'production',
+      logLevel: 'silent',
+      bundlerLogLevel: { rolldown: 'silent' },
+    })
+    const swFilePromise = fs.readFile(swDest, 'utf8')
+    await expect(swFilePromise).resolves.not.toThrow()
+    const swContent = await swFilePromise
+    expect(swContent).toContain('self.addEventListener')
+    expect(swContent.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/workbox/build/test/vite-rolldown-build-sw.spec.ts
+++ b/packages/workbox/build/test/vite-rolldown-build-sw.spec.ts
@@ -31,9 +31,11 @@ async function createFixture(
     const src = path.resolve(root, 'src')
     const dist = path.resolve(root, 'dist')
     await fs.mkdir(src, { recursive: true })
-    await fs.writeFile(path.resolve(src, 'index.js'), 'console.log("PWA test");\n')
-    await fs.writeFile(path.resolve(src, 'sw.js'), swCode, 'utf-8')
-    await fs.writeFile(path.resolve(root, 'package.json'), '{}')
+    await Promise.all([
+      fs.writeFile(path.resolve(src, 'index.js'), 'console.log("PWA test");\n'),
+      fs.writeFile(path.resolve(src, 'sw.js'), swCode, 'utf-8'),
+      fs.writeFile(path.resolve(root, 'package.json'), '{}'),
+    ])
     await use({ root, dist })
   }
   finally {

--- a/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
+++ b/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
@@ -16,25 +16,16 @@ async function createFixture(prefix: string, use: (paths: { root: string, dist: 
     const dist = path.resolve(root, 'dist')
 
     await fs.mkdir(src)
-    await fs.writeFile(
-      path.resolve(src, 'index.js'),
-      'document.body.textContent = "PWA compiler smoke"\n',
-    )
-    await fs.writeFile(
-      path.resolve(src, 'sw.js'),
-      `import { clientsClaim } from "@composable-vite-pwa/workbox-swkit/core"
+
+    const indexContent = 'document.body.textContent = "PWA compiler smoke"\n'
+    const swContent = `import { clientsClaim } from "@composable-vite-pwa/workbox-swkit/core"
 import { precacheAndRoute } from "@composable-vite-pwa/workbox-swkit/precaching"
 
 globalThis.skipWaiting()
 clientsClaim()
 precacheAndRoute(globalThis.__WB_MANIFEST)
-`,
-      'utf-8',
-    )
-    if (prefix === 'rspack') {
-      await fs.writeFile(
-        path.resolve(root, 'package.json'),
-        `{
+`
+    const rspackPackageJson = `{
   "name": "rsbuild-app",
   "type": "module",
   "version": "0.0.0",
@@ -47,14 +38,8 @@ precacheAndRoute(globalThis.__WB_MANIFEST)
     "@rsbuild/core": "catalog:rsbuild"
   }
 }
-`,
-        'utf-8',
-      )
-    }
-    else {
-      await fs.writeFile(
-        path.resolve(root, 'package.json'),
-        `{
+`
+    const webpackPackageJson = `{
   "name": "webpack-app",
   "type": "module",
   "version": "0.0.0",
@@ -67,14 +52,20 @@ precacheAndRoute(globalThis.__WB_MANIFEST)
     "webpack": "catalog:webpack5"
   }
 }
-`,
-      )
+`
+    const writePromises = [
+      fs.writeFile(path.resolve(src, 'index.js'), indexContent),
+      fs.writeFile(path.resolve(src, 'sw.js'), swContent, 'utf-8'),
+    ]
+    if (prefix === 'rspack') {
+      writePromises.push(fs.writeFile(path.resolve(root, 'package.json'), rspackPackageJson, 'utf-8'))
     }
+    else {
+      writePromises.push(fs.writeFile(path.resolve(root, 'package.json'), webpackPackageJson, 'utf-8'))
+    }
+    await Promise.all(writePromises)
 
-    await use({
-      root,
-      dist,
-    })
+    await use({ root, dist })
   }
   finally {
     if (root) {
@@ -123,10 +114,7 @@ function runRspack(config: rspack.Configuration): Promise<rspack.Stats> {
 const isWatchMode = process.env.VITEST_MODE === 'WATCH'
 
 export const testWebpack = base.extend<{
-  sandbox: {
-    root: string
-    dist: string
-  }
+  sandbox: { root: string, dist: string }
 }>({
   // eslint-disable-next-line no-empty-pattern
   sandbox: async ({}, use) => {
@@ -135,10 +123,7 @@ export const testWebpack = base.extend<{
 }).skipIf(isWatchMode)
 
 export const testRspack = base.extend<{
-  sandbox: {
-    root: string
-    dist: string
-  }
+  sandbox: { root: string, dist: string }
 }>({
   // eslint-disable-next-line no-empty-pattern
   sandbox: async ({}, use) => {
@@ -154,30 +139,23 @@ describe('webpack/rspack WorkboxPlugin', () => {
       context: root,
       devtool: false,
       entry: './src/index.js',
-      output: {
-        filename: 'main.js',
-        path: dist,
-      },
+      output: { filename: 'main.js', path: dist },
       plugins: [
-        new WebpackWorkboxPlugin(
-          'build-sw',
-          {
-            buildSW: {
-              swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
-              swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
-              globPatterns: ['**/*.js'],
-              injectionPoint: 'globalThis.__WB_MANIFEST',
-              inlineWorkboxRuntime: true,
-              sourcemap: false,
-              mode: 'development',
-              logLevel: 'silent',
-              bundlerLogLevel: { rolldown: 'silent' },
-            },
+        new WebpackWorkboxPlugin('build-sw', {
+          buildSW: {
+            swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
+            swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
+            globPatterns: ['**/*.js'],
+            injectionPoint: 'globalThis.__WB_MANIFEST',
+            inlineWorkboxRuntime: true,
+            sourcemap: false,
+            mode: 'development',
+            logLevel: 'silent',
+            bundlerLogLevel: { rolldown: 'silent' },
           },
-        ),
+        }),
       ],
     })
-
     expect(stats.toJson({ errors: true }).errors).toEqual([])
 
     const swFilePromise = fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')
@@ -193,30 +171,23 @@ describe('webpack/rspack WorkboxPlugin', () => {
       context: root,
       devtool: false,
       entry: './src/index.js',
-      output: {
-        filename: 'main.js',
-        path: dist,
-      },
+      output: { filename: 'main.js', path: dist },
       plugins: [
-        new RspackWorkboxPlugin(
-          'build-sw',
-          {
-            buildSW: {
-              swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
-              swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
-              globPatterns: ['**/*.js'],
-              injectionPoint: 'globalThis.__WB_MANIFEST',
-              inlineWorkboxRuntime: true,
-              sourcemap: false,
-              mode: 'development',
-              logLevel: 'silent',
-              bundlerLogLevel: { rolldown: 'silent' },
-            },
+        new RspackWorkboxPlugin('build-sw', {
+          buildSW: {
+            swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
+            swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
+            globPatterns: ['**/*.js'],
+            injectionPoint: 'globalThis.__WB_MANIFEST',
+            inlineWorkboxRuntime: true,
+            sourcemap: false,
+            mode: 'development',
+            logLevel: 'silent',
+            bundlerLogLevel: { rolldown: 'silent' },
           },
-        ),
+        }),
       ],
     })
-
     expect(stats.toJson({ errors: true }).errors).toEqual([])
 
     await expect(fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')).resolves.toContain('main.js')
@@ -224,7 +195,6 @@ describe('webpack/rspack WorkboxPlugin', () => {
 
   testWebpack('loads external config files for webpack builds', async ({ sandbox }) => {
     const { dist, root } = sandbox
-
     const swSrc = normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js')))
     const swDest = normalizePath(path.relative(process.cwd(), 'sw.js'))
 
@@ -254,21 +224,14 @@ describe('webpack/rspack WorkboxPlugin', () => {
       context: root,
       devtool: false,
       entry: './src/index.js',
-      output: {
-        filename: 'main.js',
-        path: dist,
-      },
+      output: { filename: 'main.js', path: dist },
       plugins: [
-        new WebpackWorkboxPlugin(
-          'build-sw',
-          {
-            cwd: root,
-            path: 'external-pwa.config.mjs',
-          },
-        ),
+        new WebpackWorkboxPlugin('build-sw', {
+          cwd: root,
+          path: 'external-pwa.config.mjs',
+        }),
       ],
     })
-
     expect(stats.toJson({ errors: true }).errors).toEqual([])
 
     await expect(fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')).resolves.toContain('main.js')

--- a/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
+++ b/packages/workbox/build/test/webpack-rspack-plugins.spec.ts
@@ -179,7 +179,11 @@ describe('webpack/rspack WorkboxPlugin', () => {
     })
 
     expect(stats.toJson({ errors: true }).errors).toEqual([])
-    await expect(fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')).resolves.toContain('main.js')
+
+    const swFilePromise = fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')
+    await expect(swFilePromise).resolves.not.toThrow()
+    const swContent = await swFilePromise
+    expect(swContent).toContain('main.js')
   })
 
   testRspack('runs build-sw with rspack compiler context and relative paths', async ({ sandbox }) => {
@@ -214,6 +218,7 @@ describe('webpack/rspack WorkboxPlugin', () => {
     })
 
     expect(stats.toJson({ errors: true }).errors).toEqual([])
+
     await expect(fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')).resolves.toContain('main.js')
   })
 
@@ -265,6 +270,7 @@ describe('webpack/rspack WorkboxPlugin', () => {
     })
 
     expect(stats.toJson({ errors: true }).errors).toEqual([])
+
     await expect(fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')).resolves.toContain('main.js')
   })
 })


### PR DESCRIPTION
## Summary
Adds smoke tests for the `buildSW` strategy using:
- Vite 8+ (modern)
- Rolldown (direct, not legacy)

The tests create a temporary app, build it, generate a service worker, and verify the output.

## Changes
- New test file: `packages/workbox/build/test/vite-rolldown-build-sw.spec.ts`
- Uses `.skipIf(isWatchMode)` to avoid running in watch mode
- Uses local `createFixture(swCode, use)` with `({}, use)` pattern (no shared helper)
- Applies two‑step promise pattern for file assertions
- Removes `test/utils.ts` (shared helper was abandoned)
- Updates `webpack-rspack-plugins.spec.ts` to use two‑step promise pattern
- Direct Rolldown `buildSW` test (not `buildSWLegacy`)

## Testing
- `pnpm test:ci` passes
- Watch mode skips these heavy tests

## Note
The async generator / transformer refactor (making `additionalManifestEntriesTransform` async, merging generator into pipeline) is **not** included – it will be handled in a separate PR after review.