### PR TITLE
test(rolldown): demonstrate plugin with closeBundle (failing - for reference only)

### DIFF
--- a/packages/workbox/build/test/rolldown-build-generate-sw.spec.ts
+++ b/packages/workbox/build/test/rolldown-build-generate-sw.spec.ts
@@ -5,32 +5,21 @@ import { describe, expect } from 'vitest'
 import { normalizePath } from '../src/build/builder/utils'
 import { buildSW as rolldownBuildSW } from '../src/build/rolldown/build-sw'
 import { testWithSandbox } from './utils/test-sandbox'
+import { createBuildSWPlugin } from './utils/plugin-utils'
 
 describe('buildSW with Rolldown', () => {
   testWithSandbox('generates a service worker directly', async ({ sandbox }) => {
     const { root, dist } = sandbox
 
+    const swPlugin = createBuildSWPlugin(root, dist, rolldownBuildSW, { rolldown: 'silent' })
+
     const build = await rolldown({
       input: path.resolve(root, 'src/index.js'),
+      plugins: [swPlugin]
     })
     await build.write({ dir: dist })
 
-    const swSrc = normalizePath(path.resolve(root, 'src/sw.js'))
     const swDest = normalizePath(path.resolve(dist, 'sw.js'))
-    const globDirectory = normalizePath(dist)
-    await rolldownBuildSW({
-      swSrc,
-      swDest,
-      globDirectory,
-      globPatterns: ['**/*.js'],
-      injectionPoint: 'self.__WB_MANIFEST',
-      inlineWorkboxRuntime: true,
-      sourcemap: false,
-      mode: 'production',
-      logLevel: 'silent',
-      bundlerLogLevel: { rolldown: 'silent' },
-    })
-
     const swFilePromise = fs.readFile(swDest, 'utf8')
     await expect(swFilePromise).resolves.not.toThrow()
     const swContent = await swFilePromise


### PR DESCRIPTION
## Description

**This PR is for reference only and is not intended to be merged.**  
It shows the attempt to use the same `createBuildSWPlugin` (with `closeBundle`) for Rolldown that works for Vite.

### Failing behaviour

- The plugin is added to the Rolldown build.
- `closeBundle` hook calls `rolldownBuildSW`.
- The test fails with `ENOENT: no such file or directory` because `sw.js` is not written.

### Why it fails

- Rolldown’s `closeBundle` hook may fire before files are fully written to disk.
- Path resolution inside the hook may differ from the direct call.

### Working solution

The direct call (without plugin) works reliably and is used in the main PR:  
**#16**
