### PR TITLE
test: add inject-manifest core spec and webpack/rspack plugin wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 ## TODO
 
-### buildSW tests — done (#16, merged)
+### buildSW tests — done
 - [x] Vite modern (`buildSW`) · Vite legacy <8 (`buildSWLegacy`) · Rolldown · webpack · rspack
 - [x] Manifest injection asserted (not just file existence)
 
-### generateSW tests — done (this branch)
+### generateSW tests — done
 - [x] Vite modern (`generateSW`) · Vite legacy <8 (`generateSWLegacy`) · Rolldown
 - [x] webpack · rspack (`WorkboxPlugin('generate-sw', { generateSW })`)
 - [x] Precache entry asserted (output filename in SW, no `__WB_MANIFEST` placeholder)
-- [x] `createGenerateSWPlugin` added to `test/utils/plugin-utils.ts` (Vite/Rolldown only) 
+- [x] `createGenerateSWPlugin` added to `test/utils/plugin-utils.ts` (Vite/Rolldown only)
 
 Note: Vite modern `generateSW` requires `workbox-swkit` to be built (`pnpm --filter @composable-vite-pwa/workbox-swkit build`) because its inner Vite build resolves packages strictly via `exports` (no source fallback). webpack/rspack route through the same Rolldown engine, which also needs the built `swkit`.
 
-### injectManifest tests
-- [ ] Vite (modern)
-- [ ] Rolldown
-- [ ] webpack
-- [ ] rspack
+### injectManifest tests — done
+- [x] Core engine (`inject-manifest.spec.ts`) — happy path + 4 error gates
+  (injection-point-not-found · multiple-injection-points · same-src-and-dest · invalid-sw-src)
+- [x] webpack · rspack wiring (`WorkboxPlugin('inject-manifest', { injectManifest })`)
+- [x] Error assertions use single-source `errors[key]` (no copied message fragments)
+
+Note: injectManifest is bundler-agnostic — one engine (`utils/build-inject-manifest.ts`), no
+per-bundler variant. It's a pure string-splice (read swSrc → replace injectionPoint → write swDest),
+so Vite/Rolldown need no dedicated wiring tests: the core spec covers the engine end-to-end, and
+webpack/rspack only verify the plugin's afterEmit → injectManifest hand-off. No `swkit` build
+required (no bundling = imports left as text).
 
 ### CJS plugin tests
 - [ ] webpack plugin

--- a/packages/workbox/build/test/inject-manifest.spec.ts
+++ b/packages/workbox/build/test/inject-manifest.spec.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect } from 'vitest'
+import { normalizePath } from '../src/build/builder/utils'
+import { injectManifest } from '../src/inject-manifest'
+import { errors } from '../src/validation/errors'
+import { testInjectManifest } from './test-helper'
+
+describe('inject-manifest', () => {
+  testInjectManifest('run inject-manifest (happy path)', async ({ sandbox }) => {
+    const fixtureDir = sandbox
+    const swSrc = normalizePath(path.resolve(fixtureDir, 'sw.js'))
+    const swDest = normalizePath(path.resolve(fixtureDir, 'sw-test.js'))
+    const globDirectory = normalizePath(fixtureDir)
+    const result = await injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })
+
+    const swContent = await fs.readFile(swDest, 'utf8')
+    expect(swContent).toContain('index.js')
+    expect(swContent).not.toContain('self.__WB_MANIFEST')
+    expect(result.count).toBeGreaterThan(0)
+  })
+
+  testInjectManifest('injection-point-not-found', async ({ sandbox }) => {
+    const swSrc = normalizePath(path.resolve(sandbox, 'no-point.js'))
+    const swDest = normalizePath(path.resolve(sandbox, 'out.js'))
+    const globDirectory = normalizePath(sandbox)
+
+    await fs.writeFile(swSrc, 'self.addEventListener(\'install\', () => {})\n', 'utf-8')
+
+    await expect(injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })).rejects.toThrow(errors['injection-point-not-found'])
+  })
+
+  testInjectManifest('multiple-injection-points', async ({ sandbox }) => {
+    const swSrc = normalizePath(path.resolve(sandbox, 'sw.js'))
+    const swDest = normalizePath(path.resolve(sandbox, 'out.js'))
+    const globDirectory = normalizePath(sandbox)
+
+    await fs.writeFile(swSrc, 'self.__WB_MANIFEST\nself.__WB_MANIFEST\n')
+
+    await expect(injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })).rejects.toThrow(errors['multiple-injection-points'])
+  })
+
+  testInjectManifest('same-src-and-dest', async ({ sandbox }) => {
+    const swSrc = normalizePath(path.resolve(sandbox, 'same.js'))
+    const swDest = swSrc
+    const globDirectory = normalizePath(sandbox)
+
+    await fs.writeFile(swSrc, 'console.log(1)\n')
+
+    await expect(injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })).rejects.toThrow(errors['same-src-and-dest'])
+  })
+
+  testInjectManifest('invalid-sw-src', async ({ sandbox }) => {
+    const swDest = normalizePath(path.resolve(sandbox, 'same.js'))
+    const globDirectory = normalizePath(sandbox)
+
+    await expect(injectManifest({
+      swSrc: 'non-existing-sw.js',
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })).rejects.toThrow(errors['invalid-sw-src'])
+  })
+})

--- a/packages/workbox/build/test/rspack-workbox-plugin.spec.ts
+++ b/packages/workbox/build/test/rspack-workbox-plugin.spec.ts
@@ -98,3 +98,35 @@ describe('rspack WorkboxPlugin (generate-sw)', () => {
     expect(swContent).not.toContain('__WB_MANIFEST')
   })
 })
+
+// ======================== InjectManifest ========================
+describe('rspack WorkboxPlugin (inject-manifest)', () => {
+  testRspack('inject-manifest', async ({ sandbox }) => {
+    const { dist, root } = sandbox
+    const stats = await runRspack({
+      mode: 'development',
+      context: root,
+      devtool: false,
+      entry: './src/index.js',
+      output: { filename: 'main.js', path: dist },
+      plugins: [
+        new RspackWorkboxPlugin('inject-manifest', {
+          injectManifest: {
+            swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
+            swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
+            globPatterns: ['**/*.js'],
+            injectionPoint: 'globalThis.__WB_MANIFEST',
+            logLevel: 'silent',
+          },
+        }),
+      ],
+    })
+    expect(stats.toJson({ errors: true }).errors).toEqual([])
+
+    const swFilePromise = fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')
+    await expect(swFilePromise).resolves.not.toThrow()
+    const swContent = await swFilePromise
+    expect(swContent).toContain('main.js')
+    expect(swContent).not.toContain('__WB_MANIFEST')
+  })
+})

--- a/packages/workbox/build/test/webpack-workbox-plugin.spec.ts
+++ b/packages/workbox/build/test/webpack-workbox-plugin.spec.ts
@@ -145,3 +145,36 @@ describe('webpack WorkboxPlugin (generate-sw)', () => {
     expect(swContent).not.toContain('__WB_MANIFEST')
   })
 })
+
+// ======================== injectManifest ========================
+describe('webpack WorkboxPlugin (inject-manifest)', () => {
+  testWebpack('inject-manifest', async ({ sandbox }) => {
+    const { dist, root } = sandbox
+
+    const stats = await runWebpack({
+      mode: 'development',
+      context: root,
+      devtool: false,
+      entry: './src/index.js',
+      output: { filename: 'main.js', path: dist },
+      plugins: [
+        new WebpackWorkboxPlugin('inject-manifest', {
+          injectManifest: {
+            swSrc: normalizePath(path.relative(process.cwd(), path.resolve(root, 'src/sw.js'))),
+            swDest: normalizePath(path.relative(process.cwd(), 'sw.js')),
+            globPatterns: ['**/*.js'],
+            injectionPoint: 'globalThis.__WB_MANIFEST',
+            logLevel: 'silent',
+          },
+        }),
+      ],
+    })
+    expect(stats.toJson({ errors: true }).errors).toEqual([])
+
+    const swFilePromise = fs.readFile(path.resolve(dist, 'sw.js'), 'utf8')
+    await expect(swFilePromise).resolves.not.toThrow()
+    const swContent = await swFilePromise
+    expect(swContent).toContain('main.js')
+    expect(swContent).not.toContain('__WB_MANIFEST')
+  })
+})


### PR DESCRIPTION
- inject-manifest.spec.ts: happy path + 4 error gates (errors[key] matchers)
- webpack/rspack: inject-manifest via WorkboxPlugin afterEmit hook
- rename webpack/rspack specs to *-workbox-plugin (mirror the plugin, not strategies)
- README: tick injectManifest, note the bundler-agnostic engine

Ready for review ( a few changes that I think need too be reviewed )