### PR TITLE
docs: add TODO to reverse strategy precedence in webpack/rspack plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ required (no bundling = imports left as text).
 
 ### Known issues / follow-ups
 - [ ] Add service worker tests
+- [ ] Reverse strategy precedence in the `@build/webpack` and `@build/rspack` plugins: a strategy
+  passed to the plugin constructor must override the config file's default strategy (currently
+  the resolved config wins — `strategy ?? buildContext.strategy` in
+  `build/builder/internal-webpack-build.ts`; update the `**WARNING**` JSDoc in both plugins when fixed)

--- a/packages/workbox/build/src/build/rspack/index.ts
+++ b/packages/workbox/build/src/build/rspack/index.ts
@@ -5,6 +5,10 @@ import { internalWebpackBuild } from '../builder/internal-webpack-build'
 /**
  * [rspack plugin](https://rspack.rs/plugins/) for Workbox build strategies.
  * **WARNING**: strategy from the resolved options will override the strategy used in the plugin constructor.
+ *
+ * TODO: review this, should be reversed — a strategy provided at the plugin constructor
+ * must override the default strategy from the resolved options
+ * (`strategy ?? buildContext.strategy` in `builder/internal-webpack-build.ts`).
  */
 export class WorkboxPlugin<
   S extends Strategy,

--- a/packages/workbox/build/src/build/webpack/index.ts
+++ b/packages/workbox/build/src/build/webpack/index.ts
@@ -8,6 +8,10 @@ import { internalWebpackBuild } from '../builder/internal-webpack-build'
 /**
  * [webpack plugin](https://webpack.js.org/plugins/) for Workbox build strategies.
  * **WARNING**: strategy from the resolved options will override the strategy used in the plugin constructor.
+ *
+ * TODO: review this, should be reversed — a strategy provided at the plugin constructor
+ * must override the default strategy from the resolved options
+ * (`strategy ?? buildContext.strategy` in `builder/internal-webpack-build.ts`).
  */
 
 export class WorkboxPlugin<


### PR DESCRIPTION
The strategy provided at the plugin constructor should override the default strategy from the resolved configuration, not the other way around. Tracked in README known issues.