### PR TITLE
chore: add build-register-sw vite plugin

### DIFF
--- a/examples/unplugin-pwa-sveltekit-manual/src/lib/components/ReloadPrompt.svelte
+++ b/examples/unplugin-pwa-sveltekit-manual/src/lib/components/ReloadPrompt.svelte
@@ -1,5 +1,5 @@
 <script lang='ts'>
-    import 'virtual:pwa-entry-point-loaded'
+    // import 'virtual:pwa-entry-point-loaded'
     import { useRegisterSW } from 'virtual:pwa-register/svelte'
 
     // replaced dynamically

--- a/examples/unplugin-pwa-sveltekit-manual/src/routes/+layout.svelte
+++ b/examples/unplugin-pwa-sveltekit-manual/src/routes/+layout.svelte
@@ -1,14 +1,35 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.svg';
+	// import { browser, dev } from '$app/environment'
 	import { pwaInfo } from 'virtual:pwa-info'
+	// import { onMount } from 'svelte';
+
+	console.log(pwaInfo)
+
 	let { children } = $props();
 
-	const webManifest = $derived(pwaInfo ? pwaInfo.webManifest.linkTag : '')
+	// const scriptTag = $derived(pwaInfo && !dev ? pwaInfo.registerSW?.scriptTag || '' : '')
+	// const webManifest = $derived(pwaInfo && !dev ? pwaInfo.webManifest.linkTag : '')
+	const webManifest = $derived(pwaInfo  ? pwaInfo.webManifest.linkTag : '')
+
+
+	/*onMount(async () => {
+		console.log(browser)
+		if (browser) {
+			import('virtual:pwa-entry-point-loaded').then(({
+				registerDevSW
+			}) => {
+				registerDevSW()
+			})
+		}
+	});*/
+
 </script>
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
 	{@html webManifest}
+	<!--{@html scriptTag}-->
 </svelte:head>
 
 {@render children()}

--- a/examples/unplugin-pwa-sveltekit-manual/sveltekit-pwa-integration.ts
+++ b/examples/unplugin-pwa-sveltekit-manual/sveltekit-pwa-integration.ts
@@ -21,12 +21,13 @@ import type {
   SWType,
 } from '@composable-vite-pwa/workbox-build/types'
 import type { Adapter } from '@sveltejs/kit'
-import type { Plugin, PluginOption } from 'vite'
+import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
 import { hash } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { generateWebManifest } from '@composable-vite-pwa/unplugin-pwa/node/generate-web-manifest'
+import { BuildRegisterSWPlugin } from '@composable-vite-pwa/unplugin-pwa/node/vite/plugins/build-register-sw'
 import { DevPlugin } from '@composable-vite-pwa/unplugin-pwa/node/vite/plugins/dev'
 import { DevMiddlewarePlugin } from '@composable-vite-pwa/unplugin-pwa/node/vite/plugins/dev-middleware'
 import { DevAssetsMiddlewarePlugin } from '@composable-vite-pwa/unplugin-pwa/node/vite/plugins/dev-pwa-assets-middleware'
@@ -163,6 +164,7 @@ function createSvelteKitPWAContext<
   const ctx = Object.assign(
     createVitePWAContext(envApi, rest),
     {
+      hmrRequiresSwitcher: true,
       kitConfig: config,
       kitOptions: kit,
     },
@@ -188,6 +190,7 @@ function SvelteKitPlugin<
     DevMiddlewarePlugin(ctx),
     DevAssetsMiddlewarePlugin(ctx),
     AssetsPlugin(ctx),
+    BuildRegisterSWPlugin(ctx),
     SvelteKitBuildPlugin(ctx),
   ]
 }
@@ -372,6 +375,24 @@ async function buildManifestEntry(url: string, path: string): Promise<ManifestEn
   }
 }
 
+function prepareEnv<
+  UserStrategy extends VitePWAStrategy,
+  S extends Strategy,
+  T extends SWType,
+>(
+  forClient: boolean,
+  config: ResolvedConfig,
+  forBuild: boolean,
+  ctx: SvelteKitPWAContext<UserStrategy, S, T>,
+) {
+  const { kitConfig = {} } = ctx
+  if (kitConfig.experimental?.explicitEnvironmentVariables === true) {
+
+  }
+  console.log(kitConfig)
+  console.log(config.resolve.alias)
+}
+
 function createPWAConfigurer<
   UserStrategy extends VitePWAStrategy,
   S extends Strategy,
@@ -383,8 +404,9 @@ function createPWAConfigurer<
     kitConfig = {},
     kitOptions = {},
   } = ctx
-  return (_forClient, config) => {
+  return (forClient, config) => {
     const buildCommand = config.command === 'build'
+    prepareEnv(forClient, config, buildCommand, ctx)
     if (!buildCommand) {
       return undefined
     }

--- a/examples/unplugin-pwa-sveltekit-manual/vite.config.ts
+++ b/examples/unplugin-pwa-sveltekit-manual/vite.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
             filename.split(/[/\\]/).includes('node_modules') ? undefined : true,
         },
 
+        experimental: {
+          explicitEnvironmentVariables: true,
+        },
+
         // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
         // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
         // See https://svelte.dev/docs/kit/adapters for more information about adapters.

--- a/packages/unplugin-pwa/info.d.ts
+++ b/packages/unplugin-pwa/info.d.ts
@@ -20,7 +20,7 @@ declare module 'virtual:pwa-info' {
      * - if using `pwaPluginOptions.injectRegister` with `auto` (default) and importing any of the virtual modules
      *
      * **NOTE**: `registerSW` will be `undefined` if:
-     * - SSR build
+     * - SSR build (only if required)
      * - PWA is disabled: `pwaPluginOptions.disable = true`
      * - running `Dev Server` and `pwaPluginOptions.devOptions.enabled = false` (default).
      */

--- a/packages/unplugin-pwa/package.json
+++ b/packages/unplugin-pwa/package.json
@@ -66,6 +66,7 @@
     "./node/vite/dev/prepare-sw-names-and-glob-directory": "./dist/node/vite/dev/prepare-sw-names-and-glob-directory.mjs",
     "./node/vite/dev/prepare-temp-folder": "./dist/node/vite/dev/prepare-temp-folder.mjs",
     "./node/vite/plugins/build": "./dist/node/vite/plugins/build.mjs",
+    "./node/vite/plugins/build-register-sw": "./dist/node/vite/plugins/build-register-sw.mjs",
     "./node/vite/plugins/dev": "./dist/node/vite/plugins/dev.mjs",
     "./node/vite/plugins/dev-middleware": "./dist/node/vite/plugins/dev-middleware.mjs",
     "./node/vite/plugins/dev-pwa-assets-middleware": "./dist/node/vite/plugins/dev-pwa-assets-middleware.mjs",

--- a/packages/unplugin-pwa/src/node/context-types.ts
+++ b/packages/unplugin-pwa/src/node/context-types.ts
@@ -121,6 +121,7 @@ export interface PWAPluginContext<
   resolvedOptions: Partial<ResolvedVitePWAOptions<S, T>>
   useImportRegister: boolean
   devEnvironment: boolean
+  hmrRequiresSwitcher?: true
   pwaAssetsGenerator: Promise<PWAAssetsGenerator | undefined>
   build: PWABuildContext
   dev: PWABuildDevContext<B, T>
@@ -147,6 +148,6 @@ export interface PWAPluginContext<
    *
    * This option will help some integrations to inject the corresponding script in the head.
    */
-  registerSWData: () => Promise<RegisterSWData | undefined>
+  registerSWData: () => Promise<RegisterSWData & { module: boolean } | undefined>
   runBuild: () => Promise<BuildResult | boolean>
 }

--- a/packages/unplugin-pwa/src/node/create-generate-register-sw-script.ts
+++ b/packages/unplugin-pwa/src/node/create-generate-register-sw-script.ts
@@ -17,7 +17,7 @@ export async function createGenerateRegisterSW(
   if (dev && !injectAtDev) {
     return undefined
   }
-  const options = dev && isDualServiceWorker(ctx)
+  const options = /* dev && */isDualServiceWorker(ctx)
     ? ' type="module"'
     : ''
 

--- a/packages/unplugin-pwa/src/node/prepare-pwa-context.ts
+++ b/packages/unplugin-pwa/src/node/prepare-pwa-context.ts
@@ -45,22 +45,35 @@ export function preparePWAContext<
       return undefined
 
     // 2: if manual registration or using virtual
-    const mode = options.injectRegister
-    if (!mode || ctx.useImportRegister)
+    let mode = options.injectRegister
+    if (!mode || ctx.useImportRegister) {
       return undefined
+    }
+
+    if (mode === 'auto') {
+      options.injectRegister = 'script'
+      mode = 'script'
+    }
+
+    console.log(mode)
 
     // 3: otherwise we always return the info
     let type: WorkerType = 'classic'
     let script: string | undefined
     let shouldRegisterSW = options.injectRegister === 'inline' || options.injectRegister === 'script' || options.injectRegister === 'script-defer'
-    if (ctx.devEnvironment && options.devOptions?.enabled === true) {
-      type = options.devOptions?.type ?? 'classic'
-      script = await createGenerateRegisterSW(ctx, true, true)
+    if (ctx.devEnvironment) {
+      if (options.devOptions?.enabled === true) {
+        type = options.devOptions?.type ?? 'classic'
+        script = await createGenerateRegisterSW(ctx, true, true)
+        shouldRegisterSW = true
+      }
+    }
+    else {
+      script = await createGenerateRegisterSW(ctx, false, true)
       shouldRegisterSW = true
     }
-    else if (shouldRegisterSW) {
-      script = await createGenerateRegisterSW(ctx, true, true)
-    }
+
+    console.log(script)
 
     const base = ctx.devEnvironment ? options.base : options.buildBase
 
@@ -68,7 +81,7 @@ export function preparePWAContext<
       // hint when required
       shouldRegisterSW,
       module: isDualServiceWorker(ctx),
-      mode: mode === 'auto' ? 'script' : mode,
+      mode,
       scope: options.scope,
       // todo: review this, this may be wrong
       inlinePath: `${base}${ctx.devEnvironment ? DEV_SW_NAME : FILE_SW_REGISTER}`,

--- a/packages/unplugin-pwa/src/node/vite/index.ts
+++ b/packages/unplugin-pwa/src/node/vite/index.ts
@@ -2,6 +2,7 @@ import type { SWType } from '@composable-vite-pwa/workbox-build/types'
 import type { PluginOption } from 'vite'
 import type { VitePWAOptions, VitePWAStrategy } from '../types'
 import { BuildPlugin } from './plugins/build'
+import { BuildRegisterSWPlugin } from './plugins/build-register-sw'
 import { DevPlugin } from './plugins/dev'
 import { DevMiddlewarePlugin } from './plugins/dev-middleware'
 import { DevAssetsMiddlewarePlugin } from './plugins/dev-pwa-assets-middleware'
@@ -31,6 +32,7 @@ export function VitePWA<
     DevMiddlewarePlugin(ctx),
     DevAssetsMiddlewarePlugin(ctx),
     AssetsPlugin(ctx),
+    BuildRegisterSWPlugin(ctx),
     BuildPlugin(ctx),
   ]
 }

--- a/packages/unplugin-pwa/src/node/vite/plugins/build-register-sw.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/build-register-sw.ts
@@ -1,0 +1,86 @@
+import type { Strategy } from '@composable-vite-pwa/workbox-build/config/types'
+import type { SWType } from '@composable-vite-pwa/workbox-build/types'
+import type { Plugin } from 'vite'
+import type { VitePWAStrategy } from '../../types'
+import type { ViteBundler, VitePWAPluginContext } from '../vite-context'
+import { FILE_SW_REGISTER } from '../../constants'
+import { generateRegisterSW } from '../../generate-register-sw'
+import { injectGenerateRegisterSW } from '../../inject-generate-register-sw'
+import { injectWebManifestHtmlLink } from '../../inject-web-manifest-html-link'
+
+export function BuildRegisterSWPlugin<
+  UserStrategy extends VitePWAStrategy,
+  S extends Strategy,
+  T extends SWType,
+>(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, S, T>): Plugin {
+  const transformIndexHtmlHandler = async (html: string) => {
+    if (!ctx.envApi && ctx.viteConfig.build.ssr) {
+      return html
+    }
+    html = injectWebManifestHtmlLink(html, ctx)
+
+    if (ctx.resolvedOptions.disable === true)
+      return html
+
+    // if virtual register is requested, do not inject.
+    if (ctx.resolvedOptions.injectRegister === 'auto') {
+      ctx.resolvedOptions.injectRegister = ctx.useImportRegister ? null : 'script'
+    }
+
+    return await injectGenerateRegisterSW(html, ctx, false, false)
+  }
+
+  return {
+    name: 'unplugin-pwa:build:register-sw',
+    enforce: 'post',
+    apply: 'build',
+    applyToEnvironment(environment) {
+      return environment.config.consumer === 'client'
+    },
+    transformIndexHtml: {
+      order: 'post',
+      async handler(html) {
+        return await transformIndexHtmlHandler(html)
+      },
+      // @ts-expect-error deprecated since Vite 4
+      enforce: 'post',
+      async transform(html: string) {
+        return await transformIndexHtmlHandler(html)
+      },
+    },
+    async generateBundle(_, bundle) {
+      if ((!ctx.envApi && ctx.viteConfig.build.ssr) || ctx.resolvedOptions.disable === true) {
+        return
+      }
+
+      const source = await generateRegisterSW(ctx)
+      if (!source) {
+        return
+      }
+
+      if (typeof this !== 'undefined' && typeof this.emitFile !== 'undefined') {
+        this.emitFile({
+          type: 'asset',
+          fileName: FILE_SW_REGISTER,
+          source,
+        })
+      }
+      else {
+        // NOTE: assigning to bundle[foo] directly is discouraged by rollup
+        // and is not supported by rolldown.
+        // The api consumers should pass in the pluginCtx in the future
+        bundle[FILE_SW_REGISTER] = {
+          // @ts-expect-error: for Vite 3 support, Vite 4 has removed `isAsset` property
+          isAsset: true,
+          type: 'asset',
+          // vite 6 deprecation: replaced with names
+          name: undefined,
+          // fix vite 6 build with manifest enabled
+          names: [],
+          source,
+          fileName: FILE_SW_REGISTER,
+        }
+      }
+    },
+  }
+}

--- a/packages/unplugin-pwa/src/node/vite/plugins/build.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/build.ts
@@ -3,18 +3,18 @@ import type { SWType } from '@composable-vite-pwa/workbox-build/types'
 import type { Plugin } from 'vite'
 import type { VitePWAStrategy } from '../../types'
 import type { ViteBundler, VitePWAPluginContext } from '../vite-context'
-import { FILE_SW_REGISTER } from '../../constants'
-import { generateRegisterSW } from '../../generate-register-sw'
+// import { FILE_SW_REGISTER } from '../../constants'
+// import { generateRegisterSW } from '../../generate-register-sw'
 import { generateWebManifest } from '../../generate-web-manifest'
-import { injectGenerateRegisterSW } from '../../inject-generate-register-sw'
-import { injectWebManifestHtmlLink } from '../../inject-web-manifest-html-link'
+// import { injectGenerateRegisterSW } from '../../inject-generate-register-sw'
+// import { injectWebManifestHtmlLink } from '../../inject-web-manifest-html-link'
 
 export function BuildPlugin<
   UserStrategy extends VitePWAStrategy,
   S extends Strategy,
   T extends SWType,
 >(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, S, T>): Plugin {
-  const transformIndexHtmlHandler = async (html: string) => {
+  /* const transformIndexHtmlHandler = async (html: string) => {
     if (!ctx.envApi && ctx.viteConfig.build.ssr) {
       return html
     }
@@ -29,7 +29,7 @@ export function BuildPlugin<
     }
 
     return await injectGenerateRegisterSW(html, ctx, false, false)
-  }
+  } */
 
   return {
     name: 'unplugin-pwa:build',
@@ -38,7 +38,7 @@ export function BuildPlugin<
     applyToEnvironment(environment) {
       return environment.config.consumer === 'client'
     },
-    transformIndexHtml: {
+    /* transformIndexHtml: {
       order: 'post',
       async handler(html) {
         return await transformIndexHtmlHandler(html)
@@ -48,7 +48,7 @@ export function BuildPlugin<
       async transform(html: string) {
         return await transformIndexHtmlHandler(html)
       },
-    },
+    }, */
     async generateBundle(_, bundle) {
       if (!ctx.envApi && ctx.viteConfig.build.ssr) {
         return
@@ -85,7 +85,7 @@ export function BuildPlugin<
         }
       }
 
-      if (ctx.resolvedOptions.disable === true) {
+      /* if (ctx.resolvedOptions.disable === true) {
         return
       }
 
@@ -116,7 +116,7 @@ export function BuildPlugin<
           source,
           fileName: FILE_SW_REGISTER,
         }
-      }
+      } */
     },
     closeBundle: {
       sequential: true,

--- a/packages/unplugin-pwa/src/node/vite/plugins/info.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/info.ts
@@ -8,7 +8,6 @@ import {
   PWA_INFO_VIRTUAL,
   RESOLVED_PWA_INFO_VIRTUAL,
 } from '../../constants'
-import { isDualServiceWorker } from '../../dual-sw-utilities'
 
 export function InfoPlugin<
   UserStrategy extends VitePWAStrategy,
@@ -85,9 +84,9 @@ async function generatePwaInfo<
   if (registerSWData) {
     const scriptTag = registerSWData.toScriptTag()
     if (scriptTag) {
-      const { mode, inlinePath, registerPath, type, scope } = registerSWData
+      const { mode, inlinePath, registerPath, type, scope, module } = registerSWData
       entry.registerSW = {
-        module: isDualServiceWorker(ctx),
+        module,
         mode,
         inlinePath,
         registerPath,

--- a/packages/unplugin-pwa/src/node/vite/pwa-assets-resolver.ts
+++ b/packages/unplugin-pwa/src/node/vite/pwa-assets-resolver.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { buildPwaAsset } from '../build-pwa-asset'
-import { DEV_PWA_REGISTER_NAME } from '../constants'
+import { DEV_PWA_DUAL_SW_SWITCHER_NAME, DEV_PWA_REGISTER_NAME } from '../constants'
 
 export function pwaAssetsResolver<
   UserStrategy extends VitePWAStrategy,
@@ -41,17 +41,43 @@ export function pwaAssetsResolver<
       ? path.resolve(base, folder, 'register.js')
       : path.resolve(base, '../../client/build', 'register.js')
 
+    let code = await fs.readFile(virtualPath, 'utf-8')
+    if (ctx.devEnvironment && ctx.hmrRequiresSwitcher) {
+      const prefaceIdx = code.indexOf('export function registerSW(')
+      const imports = code.slice(0, prefaceIdx)
+      const registerSWCode = code.slice(prefaceIdx)
+      code = `import { registerDevSW } from "./hmr.js";
+${imports}
+
+if (import.meta.hot) {
+  registerDevSW();
+}
+
+${registerSWCode}
+`
+    }
+
     return await buildPwaAsset(
-      await fs.readFile(virtualPath, 'utf-8'),
+      code,
       ctx,
       {
         resolveId(id) {
-          return id === DEV_PWA_REGISTER_NAME ? id : undefined
+          return id === DEV_PWA_REGISTER_NAME || id === DEV_PWA_DUAL_SW_SWITCHER_NAME || id === './hmr.js' ? id : undefined
         },
         async load(id) {
-          return id === DEV_PWA_REGISTER_NAME
-            ? await fs.readFile(registerPath, 'utf-8')
-            : undefined
+          if (id === DEV_PWA_REGISTER_NAME) {
+            return await fs.readFile(registerPath, 'utf-8')
+          }
+
+          if (id === './hmr.js') {
+            return await fs.readFile(path.resolve(path.dirname(registerPath), 'hmr.js'), 'utf-8')
+          }
+
+          if (id === DEV_PWA_DUAL_SW_SWITCHER_NAME) {
+            return await fs.readFile(path.resolve(path.dirname(registerPath), DEV_PWA_DUAL_SW_SWITCHER_NAME), 'utf-8')
+          }
+
+          return undefined
         },
       },
     )


### PR DESCRIPTION
This PR adds a new PWA context to add the HMR to virtual PWA modules when required: SvelteKit doesn't call `transformIndexHtml` hook, at Nuxt we use the PWA client plugin