### PR TITLE
chore: add `detectEsmServiceWorker` + warning when using injectManifest

### DIFF
--- a/examples/unplugin-pwa-nuxt-manual/modules/pwa/builders/vite/pwa-configuration.ts
+++ b/examples/unplugin-pwa-nuxt-manual/modules/pwa/builders/vite/pwa-configuration.ts
@@ -38,7 +38,7 @@ export async function initPwaConfiguration<
   }
   if (nuxt.options.dev) {
     // const cwd = resolveAlias('~~')
-    preparePWAStrategy(
+    await preparePWAStrategy(
       ctx,
       process.cwd(),
       ctx.dev.options.tempFolder,
@@ -46,7 +46,7 @@ export async function initPwaConfiguration<
     )
   }
   else {
-    preparePWAStrategy(
+    await preparePWAStrategy(
       ctx,
       process.cwd(),
       ctx.outDir,

--- a/packages/unplugin-pwa/package.json
+++ b/packages/unplugin-pwa/package.json
@@ -45,6 +45,7 @@
     },
     "./node/create-generate-register-sw-script": "./dist/node/create-generate-register-sw-script.mjs",
     "./node/create-web-manifest-html-link": "./dist/node/create-web-manifest-html-link.mjs",
+    "./node/detect-esm-service-worker": "./dist/node/detect-esm-service-worker.mjs",
     "./node/dual-sw-utilities": "./dist/node/dual-sw-utilities.mjs",
     "./node/generate-register-sw": "./dist/node/generate-register-sw.mjs",
     "./node/generate-virtual-module": "./dist/node/generate-virtual-module.mjs",
@@ -138,7 +139,8 @@
   "scripts": {
     "build": "tsdown --config-loader unrun",
     "test:typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm run build"
+    "test:ci": "vitest run",
+    "test": "vitest"
   },
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^1.0.0 || ^2.0.0",

--- a/packages/unplugin-pwa/src/node/config.ts
+++ b/packages/unplugin-pwa/src/node/config.ts
@@ -1,10 +1,12 @@
-import type { ExtractStrategy } from '@composable-vite-pwa/unplugin-pwa/node/context-types'
 import type { SWType } from '@composable-vite-pwa/workbox-build/types'
+import type { ExtractStrategy } from './context-types'
 import type { ManifestOptions, ResolvedVitePWAOptions, VitePWAOptions, VitePWAStrategy } from './types'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
+import pc from 'picocolors'
+import { detectEsmServiceWorker } from './detect-esm-service-worker'
 import { resolvePWAAssetsOptions } from './pwa-assets/options'
 
 function deepMergeObject(magicast: any, object: any) {
@@ -127,7 +129,7 @@ export async function resolvePwaConfiguration<
   const {
     pwaAssets,
     filename = 'sw.js',
-    strategies,
+    strategies = 'generateSW',
     swType,
     includeManifest = true,
     includeManifestIcons = true,
@@ -153,7 +155,12 @@ export async function resolvePwaConfiguration<
     case 'generate-sw': {
       const { workbox, generateSW, ...strategyOptions } = rest
       if (workbox && !generateSW) {
-        // todo: warn here
+        console.warn([
+          `\n${pc.yellow(pc.bold('[Vite PWA]'))} ${pc.yellow('DEPRECATION WARNING')}:`,
+          `You are using ${pc.cyan('workbox')} option, which is now deprecated.`,
+          `Please replace ${pc.cyan('workbox')} with ${pc.green('generateSW')} option.`,
+          `${pc.cyan('workbox')} option will be removed in the next major version.\n`,
+        ].join('\n'))
       }
       return Object.assign({}, strategyOptions, {
         strategy: 'generate-sw',
@@ -185,6 +192,43 @@ export async function resolvePwaConfiguration<
     }
     case 'injectManifest':
     case 'inject-manifest': {
+      if (await detectEsmServiceWorker(options)) {
+        console.warn([
+          `\n${pc.yellow(pc.bold('[Vite PWA]'))} ${pc.yellow('DEPRECATION WARNING')}:`,
+          `You are using ${pc.cyan('injectManifest')} option with an ESM service worker, which is now deprecated.`,
+          `Please migrate to ${pc.green('buildSW')} option.`,
+          `${pc.cyan('injectManifest')} option should be only used when you need to inject a manifest into an existing service worker.\n`,
+        ].join('\n'))
+
+        return Object.assign({}, rest, {
+          strategy: 'build-sw',
+          swType,
+          includeManifest,
+          includeManifestIcons,
+          includeManifestShortcutIcons,
+          includeManifestScreenshots,
+          disable,
+          injectRegister,
+          registerType,
+          useCredentials,
+          manifest,
+          manifestFilename,
+          minify,
+          updateViaCache,
+          pwaAssets: resolvedPwaAssets,
+        }, {
+          buildSW: Object.assign(rest.injectManifest ?? {}, {
+            swDest: filename,
+            swType,
+            minify,
+            maximumFileSizeToCacheInBytes,
+            throwMaximumFileSizeToCacheInBytes,
+            additionalManifestEntries,
+            additionalManifestEntriesGenerator,
+          }),
+        }) as ResolvedVitePWAOptions<ExtractStrategy<UserStrategy>, T>
+      }
+
       return Object.assign({}, rest, {
         strategy: 'inject-manifest',
         swType,

--- a/packages/unplugin-pwa/src/node/detect-esm-service-worker.ts
+++ b/packages/unplugin-pwa/src/node/detect-esm-service-worker.ts
@@ -1,0 +1,92 @@
+import type { VitePWAOptions } from './types'
+import { promises as fs } from 'node:fs'
+import pc from 'picocolors'
+
+/**
+ * Detects if the service worker source file is an ESM (ECMAScript Module) service worker.
+ * @param options The PWA options.
+ * @return whether the service worker is an ESM module or not.
+ */
+export async function detectEsmServiceWorker(
+  options: Partial<VitePWAOptions<any, any>>,
+): Promise<boolean> {
+  const { strategies = 'generateSW' } = options
+  if (!(strategies === 'injectManifest' || strategies === 'inject-manifest')) {
+    return false
+  }
+
+  const swSrc = options.injectManifest?.swSrc
+  if (!swSrc) {
+    return false
+  }
+
+  let parseSync: undefined | ((filename: string, sourceCode: string) => { program: unknown })
+  try {
+    const vite = await import('@composable-vite-pwa/workbox-build/build/vite').then(({
+      detect,
+    }) => detect({
+      vite: true,
+    }).then(({ vite }) => (
+      vite === true
+    )))
+    parseSync = vite
+      ? await import('vite').then(m => 'parseSync' in m ? m.parseSync : undefined!)
+      : await import('rolldown/utils').then(({ parseSync }) => parseSync)
+  }
+  catch {
+  }
+
+  if (!parseSync) {
+    parseSync = await import('rolldown/utils').then(({ parseSync }) => parseSync)
+  }
+
+  function visit(node: unknown): boolean {
+    if (!node || typeof node !== 'object') {
+      return false
+    }
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        if (visit(child)) {
+          return true
+        }
+      }
+    }
+
+    const record = node as Record<string, unknown> & { type?: string }
+    switch (record.type) {
+      case 'ImportExpression':
+        throw new Error(
+          `\n${pc.red(pc.bold('[Vite PWA]'))} ${pc.red(`Dynamic import() is not supported in a service worker: ${swSrc}!`)}\n`,
+        )
+      case 'ExportNamedDeclaration':
+      case 'ExportDefaultDeclaration':
+      case 'ExportAllDeclaration':
+        throw new Error(
+          `\n${pc.red(pc.bold('[Vite PWA]'))} ${pc.red(`Export declarations are not supported in a service worker: ${swSrc}!`)}\n`,
+        )
+      case 'ImportDeclaration':
+      case 'MetaProperty': // import.meta
+        return true
+    }
+
+    for (const key in record) {
+      if (key !== 'type') {
+        if (visit(record[key])) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  try {
+    return visit(parseSync!(
+      swSrc,
+      await fs.readFile(swSrc, 'utf-8'),
+    ).program)
+  }
+  catch {
+    return false
+  }
+}

--- a/packages/unplugin-pwa/src/node/types.ts
+++ b/packages/unplugin-pwa/src/node/types.ts
@@ -194,11 +194,6 @@ export interface VitePWAOptions<
    */
   swType?: T
   /**
-   * TODO: is this necessary??
-   * @default 'public'
-   */
-  srcDir?: string
-  /**
    * @default 'dist'
    */
   outDir?: string

--- a/packages/unplugin-pwa/src/node/vite/helpers.ts
+++ b/packages/unplugin-pwa/src/node/vite/helpers.ts
@@ -1,4 +1,3 @@
-import type { ExtractStrategy } from '@composable-vite-pwa/unplugin-pwa/node/context-types'
 import type {
   BasePartial,
   ManifestEntry,
@@ -7,6 +6,7 @@ import type {
   SWType,
 } from '@composable-vite-pwa/workbox-build/types'
 import type { ResolvedConfig } from 'vite'
+import type { ExtractStrategy } from '../context-types'
 import type {
   ResolvedBuildSW,
   ResolvedGenerateSW,
@@ -16,10 +16,10 @@ import type {
 } from '../types'
 import type { ViteBundler, VitePWAPluginContext } from './vite-context'
 import path from 'node:path'
-import { prepareSwNames } from '@composable-vite-pwa/unplugin-pwa/node/prepare-sw-names'
 import pc from 'picocolors'
 import { additionalManifestEntriesFactory } from '../additional-manifest-entries'
 import { prepareManifest } from '../config'
+import { prepareSwNames } from '../prepare-sw-names'
 
 const normalizePathRegexp = /\\/g
 
@@ -125,12 +125,12 @@ export function preparePWAAssetsGenerator<
 
 /**
  * Configures the PWA strategy at the resolved PWA options.
- * @param ctx
- * @param cwd
- * @param outDir
- * @param immutableAssets
+ * @param ctx The PWA context.
+ * @param cwd The current working directory.
+ * @param outDir The output directory.
+ * @param immutableAssets The immutable assets directory.
  */
-export function preparePWAStrategy<
+export async function preparePWAStrategy<
   UserStrategy extends VitePWAStrategy,
   T extends SWType,
 >(
@@ -315,7 +315,7 @@ export async function preparePWAContextDefaults<
     }
   }
   normalizeManifest(ctx)
-  preparePWAStrategy(ctx, cwd, outDir, immutableAssets)
+  await preparePWAStrategy(ctx, cwd, outDir, immutableAssets)
   preparePWAAssetsGenerator(ctx)
   // todo: review this for self-destroy-sw
   if (!ctx.devEnvironment && !ctx.resolvedOptions.disable) {

--- a/packages/unplugin-pwa/test/detect-esm-service-worker.spec.ts
+++ b/packages/unplugin-pwa/test/detect-esm-service-worker.spec.ts
@@ -1,0 +1,50 @@
+import type { VitePWAOptions } from '../src/node/types'
+import { describe, expect, it } from 'vitest'
+import { detectEsmServiceWorker } from '../src/node/detect-esm-service-worker'
+
+describe('detect esm service worker works as expected', () => {
+  it('detects esm syntax', async () => {
+    const pwaOptions: Partial<VitePWAOptions<'inject-manifest', 'classic'>> = {
+      strategies: 'inject-manifest',
+      filename: 'test/fixtures/detect-esm-service-worker/sw.js',
+      injectManifest: {
+        swSrc: 'test/fixtures/detect-esm-service-worker/esm-sw.js',
+      },
+    }
+
+    await expect(detectEsmServiceWorker(pwaOptions)).resolves.toBe(true)
+  })
+  it('detects esm syntax with TS', async () => {
+    const pwaOptions: Partial<VitePWAOptions<'inject-manifest', 'classic'>> = {
+      strategies: 'inject-manifest',
+      filename: 'test/fixtures/detect-esm-service-worker/sw.js',
+      injectManifest: {
+        swSrc: 'test/fixtures/detect-esm-service-worker/esm-sw-ts.ts',
+      },
+    }
+
+    await expect(detectEsmServiceWorker(pwaOptions)).resolves.toBe(true)
+  })
+  it('detects no esm syntax', async () => {
+    const pwaOptions: Partial<VitePWAOptions<'inject-manifest', 'classic'>> = {
+      strategies: 'inject-manifest',
+      filename: 'test/fixtures/detect-esm-service-worker/sw.js',
+      injectManifest: {
+        swSrc: 'test/fixtures/detect-esm-service-worker/no-esm-imports-sw.js',
+      },
+    }
+
+    await expect(detectEsmServiceWorker(pwaOptions)).resolves.toBe(false)
+  })
+  it('detects no esm syntax with importScripts', async () => {
+    const pwaOptions: Partial<VitePWAOptions<'inject-manifest', 'classic'>> = {
+      strategies: 'inject-manifest',
+      filename: 'test/fixtures/detect-esm-service-worker/sw.js',
+      injectManifest: {
+        swSrc: 'test/fixtures/detect-esm-service-worker/import-scripts-sw.js',
+      },
+    }
+
+    await expect(detectEsmServiceWorker(pwaOptions)).resolves.toBe(false)
+  })
+})

--- a/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/esm-sw-ts.ts
+++ b/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/esm-sw-ts.ts
@@ -1,0 +1,3 @@
+import { clientsClaim } from '@composable-vite-pwa/workbox-swkit'
+
+clientsClaim()

--- a/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/esm-sw.js
+++ b/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/esm-sw.js
@@ -1,0 +1,3 @@
+import { clientsClaim } from '@composable-vite-pwa/workbox-swkit'
+
+clientsClaim()

--- a/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/import-scripts-sw.js
+++ b/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/import-scripts-sw.js
@@ -1,0 +1,5 @@
+importScripts('./chunk.js', 'https://storage.googleapis.com/workbox-cdn/releases/6.4.1/workbox-sw.js')
+
+workbox.setConfig({
+  modulePathPrefix: '/third_party/workbox-vX.Y.Z/',
+})

--- a/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/no-esm-imports-sw.js
+++ b/packages/unplugin-pwa/test/fixtures/detect-esm-service-worker/no-esm-imports-sw.js
@@ -1,0 +1,1 @@
+self.skipWaiting()

--- a/packages/unplugin-pwa/vitest.config.ts
+++ b/packages/unplugin-pwa/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defaultExclude, defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -9,11 +9,6 @@ export default defineConfig({
           name: 'node',
           environment: 'node',
           include: ['test/*.spec.ts'],
-          exclude: [
-            'test/fixtures/**',
-            'test/generate-sw.spec.ts',
-            ...defaultExclude,
-          ],
         },
       },
     ],


### PR DESCRIPTION
Should we parse  importScripts to copy relative assets? Maybe we need the logic since we force to include the service worker at source folder.

@houtanrocky when you have some free time update the todo issue including this