### PR TITLE
feat(workbox): add sw type to plugins factory function

### DIFF
--- a/examples/unplugin-pwa-nuxt-manual/modules/pwa/prepare-module.ts
+++ b/examples/unplugin-pwa-nuxt-manual/modules/pwa/prepare-module.ts
@@ -226,6 +226,9 @@ export async function prepareModule<
 
   if (!nuxt.options.dev) {
     if (semver.gte(ctx.nuxt.nuxtVersion, '3.8.0')) {
+      // nuxt 5 should use nitro 'vite:before:compile' hook and maybe this hook is wrong
+      // nuxt 5 has this new option experimental.nitroViteEnvironment to enable nitro/vite (v3)
+      // maybe we even need a new hook at nitro v3
       nuxt.hook('nitro:build:public-assets', async () => {
         await buildPwaAssets(ctx as unknown as any)
       })

--- a/examples/unplugin-pwa-vite8-ts/package.json
+++ b/examples/unplugin-pwa-vite8-ts/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@composable-vite-pwa/unplugin-pwa": "workspace:*",
     "@composable-vite-pwa/workbox-build": "workspace:*",
+    "@sentry/vite-plugin": "catalog:utils",
     "@vitejs/devtools": "catalog:inspector",
     "magic-string": "catalog:utils",
     "magicast": "catalog:utils",

--- a/examples/unplugin-pwa-vite8-ts/vite.config.ts
+++ b/examples/unplugin-pwa-vite8-ts/vite.config.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'vite'
 import { VitePWA } from '@composable-vite-pwa/unplugin-pwa'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { DevTools } from '@vitejs/devtools'
 import { defineConfig } from 'vite'
 import Inspect from 'vite-plugin-inspect'
@@ -191,7 +192,24 @@ export default defineConfig({
             return 'sw-helper'
           }
         },
-        plugins: () => [virtualMessagePlugin()],
+        plugins: (swType) => {
+          // if (swType === 'classic') {
+          //   return [virtualMessagePlugin()]
+          // }
+
+          return [
+            virtualMessagePlugin(),
+            sentryVitePlugin({
+              org: 'dummy-org',
+              project: 'dummy-project',
+              authToken: 'dummy-token',
+              telemetry: false,
+              release: { name: 'repro-release' },
+              // Prevent it from trying to upload anything (that would require real authentication)
+              sourcemaps: { disable: true },
+            }),
+          ]
+        },
       },
       generateSW: {
         sourcemap: true,

--- a/examples/unplugin-pwa-vite8-ts/vite.config.ts
+++ b/examples/unplugin-pwa-vite8-ts/vite.config.ts
@@ -192,7 +192,7 @@ export default defineConfig({
             return 'sw-helper'
           }
         },
-        plugins: (swType) => {
+        plugins: (_swType) => {
           // if (swType === 'classic') {
           //   return [virtualMessagePlugin()]
           // }

--- a/packages/react-router/src/create-pwa-context.ts
+++ b/packages/react-router/src/create-pwa-context.ts
@@ -209,8 +209,8 @@ async function addBuildPlugin(
 ) {
   const consumerPlugins = buildSW.plugins
   const swPlugin = await import('./plugins/runtime/sw').then(({ SWPlugin }) => SWPlugin(ctx))
-  buildSW.plugins = () => {
-    const plugins = consumerPlugins?.() ?? []
+  buildSW.plugins = (swType) => {
+    const plugins = consumerPlugins?.(swType) ?? []
     plugins.unshift(swPlugin)
     return plugins
   }

--- a/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
@@ -101,6 +101,7 @@ export function DevtoolsPlugin<
           name: 'unplugin-pwa:service-worker-info',
           type: 'action',
           handler: () => {
+            console.log(ctx.sources)
             const devOptions = ctx.resolvedOptions.devOptions
             const dependencies = devOptions?.enabled === true && ctx.dev.options?.swAssetKeys
               ? [...ctx.dev.options.swAssetKeys].filter(d => !d.endsWith('.map'))

--- a/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
@@ -101,7 +101,6 @@ export function DevtoolsPlugin<
           name: 'unplugin-pwa:service-worker-info',
           type: 'action',
           handler: () => {
-            console.log(ctx.sources)
             const devOptions = ctx.resolvedOptions.devOptions
             const dependencies = devOptions?.enabled === true && ctx.dev.options?.swAssetKeys
               ? [...ctx.dev.options.swAssetKeys].filter(d => !d.endsWith('.map'))

--- a/packages/workbox/build/src/build/builder/bundler-types.ts
+++ b/packages/workbox/build/src/build/builder/bundler-types.ts
@@ -18,7 +18,7 @@ export interface BundlerOptions {
   swChunkName: string
   swDest: string
   originalSWType: SWType
-  swType: 'classic' | 'module'
+  swType: WorkerType
   target: SWTargets
   minify: boolean
   inlineWorkboxRuntime: true | {

--- a/packages/workbox/build/src/build/rolldown/build-sw.ts
+++ b/packages/workbox/build/src/build/rolldown/build-sw.ts
@@ -18,7 +18,7 @@ function prepareRolldownBuilds<T extends SWType>(
 
   return context.builds.map(async (b) => {
     b.detectCircularDeps = withCustomChunks ? true : undefined
-    const plugins = options.plugins?.() || []
+    const plugins = options.plugins?.(b.swType) || []
     return await prepareRolldownBuild(Object.assign(b, {
       customChunks: options.customChunks,
       logLevel,

--- a/packages/workbox/build/src/build/rolldown/types.ts
+++ b/packages/workbox/build/src/build/rolldown/types.ts
@@ -6,7 +6,7 @@ export type AllResolveOptions = NonNullable<import('rolldown').InputOptions['res
 export interface ServiceWorkerOptions {
   define?: import('rolldown').TransformOptions['define']
   alias?: AllResolveOptions['alias']
-  plugins?: () => import('rolldown').Plugin[]
+  plugins?: (swType: WorkerType) => import('rolldown').Plugin[]
   sourcemap?: import('rolldown').OutputOptions['sourcemap']
 }
 

--- a/packages/workbox/build/src/build/vite/build-sw.ts
+++ b/packages/workbox/build/src/build/vite/build-sw.ts
@@ -9,9 +9,10 @@ import { createBuildContext } from './build-context'
 
 async function prepareBuildSWPlugins(
   plugins: ServiceWorkerOptions['plugins'],
+  swType: WorkerType,
   asyncFlatten: typeof import('../builder/utils')['asyncFlatten'],
 ): Promise<import('vite').PluginOption[]> {
-  const pluginsFactoryResult = plugins ? plugins() : []
+  const pluginsFactoryResult = plugins ? plugins(swType) : []
   const pluginsArray = Array.isArray(pluginsFactoryResult)
     ? pluginsFactoryResult
     : [pluginsFactoryResult]
@@ -34,6 +35,7 @@ function prepareViteBuilds<T extends SWType>(
     b.detectCircularDeps = withCustomChunks ? true : undefined
     return await prepareBuildSWPlugins(
       options.plugins,
+      b.swType,
       asyncFlatten,
     ).then((plugins) => {
       return prepareViteBuild(Object.assign(b, {

--- a/packages/workbox/build/src/build/vite/legacy-build-sw.ts
+++ b/packages/workbox/build/src/build/vite/legacy-build-sw.ts
@@ -17,7 +17,7 @@ function prepareRolldownBuilds<T extends SWType>(
   const withCustomChunks = !!options.customChunks
 
   return context.builds.map((b) => {
-    const plugins = options.plugins?.() || []
+    const plugins = options.plugins?.(b.swType) || []
     b.detectCircularDeps = withCustomChunks ? true : undefined
     return prepareRolldownBuild(Object.assign(b, {
       customChunks: options.customChunks,

--- a/packages/workbox/build/src/build/vite/legacy-types.ts
+++ b/packages/workbox/build/src/build/vite/legacy-types.ts
@@ -5,7 +5,7 @@ export interface ServiceWorkerOptions {
   define?: import('rolldown').TransformOptions['define']
   envDir?: string | false
   envPrefix?: string | string[]
-  plugins?: () => import('rolldown').Plugin[]
+  plugins?: (swType: WorkerType) => import('rolldown').Plugin[]
   sourcemap?: import('rolldown').OutputOptions['sourcemap']
 }
 

--- a/packages/workbox/build/src/build/vite/types.ts
+++ b/packages/workbox/build/src/build/vite/types.ts
@@ -17,7 +17,7 @@ export interface ServiceWorkerOptions {
    * @see https://vite.dev/guide/env-and-mode#env-files
    */
   envPrefix?: import('vite').UserConfig['envPrefix']
-  plugins?: () => import('vite').PluginOption[]
+  plugins?: (swType: WorkerType) => import('vite').PluginOption[]
   sourcemap?: import('vite').BuildOptions['sourcemap']
 }
 

--- a/packages/workbox/window/src/esm-sw-detector.ts
+++ b/packages/workbox/window/src/esm-sw-detector.ts
@@ -56,22 +56,23 @@ const esmServiceWorkerRegex = {
   split: /[._]/,
 } as const
 
+// ORDER MATTERS: most-specific browser tokens first, generic chrome/firefox/opera last
 const esmServiceWorkerRules: Record<Browser, Rule> = {
-  'chrome': (userAgent, os) => (!os || os !== 'Android') ? esmServiceWorkerRegex.chrome.exec(userAgent) : null,
   'edge-chromium': userAgent => esmServiceWorkerRegex.edge.exec(userAgent),
+  'samsung': userAgent => esmServiceWorkerRegex.samsung.exec(userAgent),
+  'uc-browser-android': (userAgent, os) => os === 'Android' && esmServiceWorkerRegex.operaMobile.test(userAgent) ? esmServiceWorkerRegex.ucBrowser.exec(userAgent) : null,
+  'qq-browser': userAgent => esmServiceWorkerRegex.qq.exec(userAgent),
+  'chromium-webview': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.webview.exec(userAgent) : null,
+  'opera-mobile': userAgent => esmServiceWorkerRegex.operaMobile.test(userAgent) ? esmServiceWorkerRegex.opera.exec(userAgent) : null,
+  'opera': userAgent => esmServiceWorkerRegex.operaMobile.test(userAgent) ? null : esmServiceWorkerRegex.opera.exec(userAgent),
+  'firefox-android': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.firefoxVersion.exec(userAgent) : null,
+  'firefox': userAgent => esmServiceWorkerRegex.firefoxVersion.exec(userAgent),
+  'chrome-android': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.chrome.exec(userAgent) : null,
+  'ios-safari': (userAgent, os) => os === 'iOS' ? esmServiceWorkerRegex.safariVersion.exec(userAgent) : null,
+  'chrome': (userAgent, os) => (!os || os !== 'Android') ? esmServiceWorkerRegex.chrome.exec(userAgent) : null,
   'safari': (userAgent, os) => {
     return os === 'Mac OS' && esmServiceWorkerRegex.safari.test(userAgent) ? esmServiceWorkerRegex.safariVersion.exec(userAgent) : null
   },
-  'firefox': userAgent => esmServiceWorkerRegex.firefoxVersion.exec(userAgent),
-  'opera': userAgent => esmServiceWorkerRegex.operaMobile.test(userAgent) ? null : esmServiceWorkerRegex.opera.exec(userAgent),
-  'chrome-android': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.chrome.exec(userAgent) : null,
-  'ios-safari': (userAgent, os) => os === 'iOS' ? esmServiceWorkerRegex.safariVersion.exec(userAgent) : null,
-  'samsung': userAgent => esmServiceWorkerRegex.samsung.exec(userAgent),
-  'opera-mobile': userAgent => esmServiceWorkerRegex.operaMobile.test(userAgent) ? esmServiceWorkerRegex.opera.exec(userAgent) : null,
-  'uc-browser-android': (userAgent, os) => os === 'Android' && esmServiceWorkerRegex.operaMobile.test(userAgent) ? esmServiceWorkerRegex.ucBrowser.exec(userAgent) : null,
-  'chromium-webview': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.webview.exec(userAgent) : null,
-  'firefox-android': (userAgent, os) => os === 'Android' ? esmServiceWorkerRegex.firefoxVersion.exec(userAgent) : null,
-  'qq-browser': userAgent => esmServiceWorkerRegex.qq.exec(userAgent),
 }
 
 export function isServiceWorkerModuleSupported(userAgent = navigator.userAgent): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ catalogs:
     '@rolldown/pluginutils':
       specifier: ^1.0.1
       version: 1.0.1
+    '@sentry/vite-plugin':
+      specifier: ^5.4.0
+      version: 5.4.0
     '@vite-pwa/assets-generator':
       specifier: ^1.0.2
       version: 1.0.2
@@ -801,6 +804,9 @@ importers:
       '@composable-vite-pwa/workbox-build':
         specifier: workspace:*
         version: link:../../packages/workbox/build
+      '@sentry/vite-plugin':
+        specifier: catalog:utils
+        version: 5.4.0(rollup@4.62.2)(webpack@5.107.1)
       '@vitejs/devtools':
         specifier: catalog:inspector
         version: 0.4.1(crossws@0.4.10)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2)(vite@8.1.0)
@@ -4232,6 +4238,82 @@ packages:
       '@swc/helpers':
         optional: true
 
+  '@sentry/bundler-plugins@10.67.0':
+    resolution: {integrity: sha512-HKLhbMZJsabZlXTog8CTa1ReeDW/mf1cwN7O8K+DKhe/kGHB3whHRseqsyjxyJwPdzC/0lM+8rgfqgxpc7jR9A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
+
   '@shikijs/core@4.3.1':
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
@@ -5437,6 +5519,10 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -6943,6 +7029,10 @@ packages:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -8220,6 +8310,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -8233,6 +8327,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   publint@0.3.21:
     resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
@@ -12391,6 +12488,81 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
+  '@sentry/bundler-plugins@10.67.0(rollup@4.62.2)(webpack@5.107.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.67.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.2
+      webpack: 5.107.1(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/vite-plugin@5.4.0(rollup@4.62.2)(webpack@5.107.1)':
+    dependencies:
+      '@sentry/bundler-plugins': 10.67.0(rollup@4.62.2)(webpack@5.107.1)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
   '@shikijs/core@4.3.1':
     dependencies:
       '@shikijs/primitive': 4.3.1
@@ -14402,6 +14574,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
@@ -16182,6 +16360,13 @@ snapshots:
       - supports-color
 
   http-shutdown@1.2.2: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -18006,6 +18191,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -18020,6 +18207,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   publint@0.3.21:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ patchedDependencies:
 
 allowBuilds:
   '@parcel/watcher': false
+  '@sentry/cli': true
   core-js: false
   esbuild: false
   sharp: true
@@ -152,6 +153,7 @@ catalogs:
     '@antfu/ni': ^25.0.0
     '@arethetypeswrong/core': ^0.18.5
     '@clack/prompts': ^1.5.1
+    '@sentry/vite-plugin': ^5.4.0
     '@vite-pwa/assets-generator': ^1.0.2
     ansis: ^4.2.0
     cac: ^7.0.0


### PR DESCRIPTION
This PR also includes:
- workbox window esm detector rules priority: moved specific rules first with a hint
- sentry plugin at vite 8 ts example for dual SW build (resolves some issue: if sentry missing there is no problem, we use separated builds: https://github.com/vite-pwa/nuxt/issues/132#issuecomment-5045919433)