### PR TITLE
feat(inspector): include SW chuncks and deps

### DIFF
--- a/packages/unplugin-pwa/inspector/src/App.vue
+++ b/packages/unplugin-pwa/inspector/src/App.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import ErrorBoundary from './components/ErrorBoundary.vue'
+import ErrorBoundaryError from './components/ErrorBoundaryError.vue'
 import InspectorHero from './components/InspectorHero.vue'
 import NavTabs from './components/NavTabs.vue'
 import PWAInfo from './components/PWAInfo.vue'
+import { ready } from './state'
 
 onMounted(async () => {
   await import('./api').then(({ loadPWAConfiguration }) => loadPWAConfiguration())
+  ready.value = true
 })
 </script>
 
@@ -15,12 +19,17 @@ onMounted(async () => {
     <PWAInfo class="border-l border-main row-span-2" />
     <NavTabs />
     <div class="col-span-2 h-full of-hidden">
-      <Suspense>
-        <RouterView />
-        <template #fallback>
-          Loading...
+      <ErrorBoundary>
+        <Suspense>
+          <RouterView />
+          <template #fallback>
+            Loading...
+          </template>
+        </Suspense>
+        <template #error="{ clearError }">
+          <ErrorBoundaryError @clear-error="clearError" />
         </template>
-      </Suspense>
+      </ErrorBoundary>
     </div>
   </div>
 </template>

--- a/packages/unplugin-pwa/inspector/src/api.ts
+++ b/packages/unplugin-pwa/inspector/src/api.ts
@@ -1,6 +1,6 @@
 import type { PWAConfiguration, SWInfo } from './state'
 import { fecthSWInfo, fetchMode, fetchPWAConfiguration } from './api/fetcher'
-import { currentSWInfo, error, pwaConfiguration, ready } from './state'
+import { currentSWInfo, pwaConfiguration, ready } from './state'
 
 let api: {
   load: () => Promise<PWAConfiguration>
@@ -39,15 +39,9 @@ async function initApi(): Promise<void> {
 }
 
 export async function loadPWAConfiguration(): Promise<void> {
-  try {
-    await initApi()
-    pwaConfiguration.value = await api.load()
-    ready.value = true
-  }
-  catch (e) {
-    console.error('cannot initialize pa configuration', e)
-    error.value = true
-  }
+  await initApi()
+  pwaConfiguration.value = await api.load()
+  ready.value = true
 }
 
 export async function loadSWInfo(): Promise<void> {

--- a/packages/unplugin-pwa/inspector/src/components/ErrorBoundary.vue
+++ b/packages/unplugin-pwa/inspector/src/components/ErrorBoundary.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed, nextTick, onErrorCaptured } from 'vue'
+import { useRoute } from 'vue-router'
+import { error, loadingSW, swReady } from '../state'
+
+const route = useRoute()
+
+// using Vue's build in lifecycle hook
+// listen for errors from components passed to the default slot
+onErrorCaptured((err: unknown) => {
+  // set the reactive error container to the thrown error
+  error.value = err
+
+  // return false to prevent error from bubbling further
+  // (this is optional, if you have a top level error reporter catching errors
+  // you probably don't want to do this.
+  // Alternatively you could report your errors in the boundary and prevent bubble
+  return false
+})
+
+// create a way to clear the error
+function clearError() {
+  error.value = undefined
+  if (route.name === '/sw') {
+    nextTick(() => {
+      loadingSW.value = true
+      new Promise(resolve => setTimeout(resolve, 256)).then(() => {
+        import('../api').then(({
+          loadSWInfo,
+        }) => loadSWInfo()).then(() => {
+          swReady.value = true
+        }).catch((err: unknown) => {
+          error.value = err
+        }).finally(() => {
+          loadingSW.value = false
+        })
+      })
+    })
+  }
+}
+
+// provide the error and the clear error function to the slot
+// for use in consuming component to display messaging
+// and clear the error
+const slotProps = computed(() => {
+  if (!error.value) {
+    return {}
+  }
+  return { clearError }
+})
+
+// if there's an error show the error slot, otherwise show the default slot
+const slotName = computed(() => (error.value ? 'error' : 'default'))
+</script>
+
+<template>
+  <slot :name="slotName" v-bind="slotProps" />
+</template>

--- a/packages/unplugin-pwa/inspector/src/components/ErrorBoundaryError.vue
+++ b/packages/unplugin-pwa/inspector/src/components/ErrorBoundaryError.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { error } from '../state'
+
+const emit = defineEmits<{
+  (evt: 'clearError'): void
+}>()
+</script>
+
+<template>
+  <div class="h-full w-full flex items-center justify-center p-8">
+    <div class="grid grid-cols-[auto_1fr] p-4 gap-x-4 gap-y-2 items-start rounded-md border border-[#dc2626] dark:border-[#fca5a5]">
+      <span aria-hidden="true" class="block i-tabler:alert-triangle text-4xl text-[#dc2626] dark:text-[#fca5a5] row-span-3 self-start mt-1" />
+
+      <p class="text-lg font-semibold text-[#dc2626] dark:text-[#fca5a5] m-0 py-2">
+        An error occurred while loading the page.
+      </p>
+
+      <p v-if="error" class="text-sm text-[#dc2626] dark:text-[#fca5a5] m-0">
+        {{ error?.message }}
+      </p>
+
+      <button class="mt-2 px-4 py-2 justify-self-end font-semibold text-white dark:text-[#7f1d1d] bg-[#dc2626] dark:bg-[#fca5a5] hover:bg-red-700 dark:hover:bg-red-400 transition-colors rounded-md" @click="emit('clearError')">
+        Clear Error
+      </button>
+    </div>
+  </div>
+</template>

--- a/packages/unplugin-pwa/inspector/src/components/NavTabs.vue
+++ b/packages/unplugin-pwa/inspector/src/components/NavTabs.vue
@@ -1,4 +1,13 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { error, loadingSW, ready } from '../state'
+
+const route = useRoute()
+
+const loading = computed(() => {
+  return route.name === '/' && !ready.value && !error.value
+})
 </script>
 
 <template>
@@ -11,7 +20,7 @@
           class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
           active-class="text-blue-600 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 font-medium"
         >
-          <span aria-hidden="true" class="block i-tabler:file w-5 h-5" />
+          <span aria-hidden="true" class="block w-5 h-5" :class="loading ? 'i-svg-spinners:ring-resize' : 'i-tabler:file'" />
           <span>Manifest</span>
         </RouterLink>
 
@@ -21,7 +30,7 @@
           class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
           active-class="text-blue-600 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 font-medium"
         >
-          <span aria-hidden="true" class="block i-mdi:gear w-5 h-5" />
+          <span aria-hidden="true" class="block w-5 h-5" :class="loadingSW ? 'i-svg-spinners:ring-resize' : 'i-mdi:gear'" />
           <span>Service Worker</span>
         </RouterLink>
       </div>

--- a/packages/unplugin-pwa/inspector/src/components/PWAManifest.vue
+++ b/packages/unplugin-pwa/inspector/src/components/PWAManifest.vue
@@ -28,7 +28,7 @@ const showMinimumSafeArea = shallowRef(false)
 
 <template>
   <div class="h-full relative overflow-hidden">
-    <div class="manifest-container h-full overflow-y-auto py3 text-sm">
+    <div class="h-full overflow-y-auto py3 text-sm">
       <h1 class="text-lg font-bold mb-6 mx-4 flex items-center gap-2">
         <span>Manifest</span>
       </h1>

--- a/packages/unplugin-pwa/inspector/src/components/ServiceWorker.vue
+++ b/packages/unplugin-pwa/inspector/src/components/ServiceWorker.vue
@@ -1,65 +1,123 @@
 <script setup lang="ts">
+import type { ScrollSpyHeader } from '../utils'
+import { onMounted, shallowRef } from 'vue'
 import { swInfo } from '../state'
+import ServiceWorkerScrollSpy from './ServiceWorkerScrollSpy.vue'
+
+const resolvedHeaders = shallowRef<ScrollSpyHeader[] | undefined>()
+
+onMounted(() => {
+  const elements = document.querySelectorAll<HTMLHeadElement>('h2')
+  const headers: ScrollSpyHeader[] = []
+  for (const element of elements) {
+    const id = element.getAttribute('id')
+    if (!id) {
+      continue
+    }
+    headers.push({
+      id,
+      element,
+      link: `/#${id}/`,
+    })
+  }
+  resolvedHeaders.value = headers
+})
 </script>
 
 <template>
-  <div class="h-full overflow-y-auto py3 text-sm">
-    <h1 class="text-lg font-bold mb-6 mx-4 flex items-center gap-2">
-      <span>Service Worker</span>
-    </h1>
+  <div class="h-full relative overflow-hidden">
+    <div class="h-full overflow-y-auto py3 text-sm">
+      <h1 id="service-worker" tabindex="-1" class="text-lg font-bold mb-6 mx-4 flex items-center gap-2">
+        <span>Service Worker</span>
+      </h1>
 
-    <div v-if="!swInfo" class="font-bold text-gray-500 dark:text-gray-400 italic pl-4">
-      Loading service worker info...
-    </div>
-
-    <div v-else class="flex flex-col gap-8">
-      <div class="grid grid-cols-[190px_1fr] gap-y-3 gap-x-4 pl-4">
-        <div class="text-gray-500 dark:text-gray-400">
-          Enabled at build time
-        </div>
-        <div class="font-mono">
-          {{ swInfo.buildEnabled ? 'Yes' : 'No' }}
-        </div>
-        <div class="text-gray-500 dark:text-gray-400">
-          Enabled at development
-        </div>
-        <div class="font-mono">
-          {{ swInfo.devEnabled ? 'Yes' : 'No' }}
-        </div>
-        <template v-if="swInfo.devEnabled">
-          <div class="text-gray-500 dark:text-gray-400">
-            Current type
-          </div>
-          <div class="font-mono">
-            {{ swInfo.currentType || '--' }}
-          </div>
-        </template>
+      <div v-if="!swInfo" class="font-bold text-gray-500 dark:text-gray-400 italic pl-4">
+        Loading service worker info...
       </div>
-      <section>
-        <h2 class="text-md font-semibold pb-2 mx-4 mb-0 flex items-center gap-2">
-          Chunks
-        </h2>
-        <hr class="mb-4 border-t border-gray-300 dark:border-gray-700">
 
-        <div v-if="!swInfo.currentType || !swInfo.dependencies || swInfo.dependencies.length === 0" class="text-gray-500 dark:text-gray-400 pl-4">
-          No chunks available.
-        </div>
+      <div v-else class="flex flex-col gap-8">
+        <section>
+          <h2 id="info" tabindex="-1" class="text-md font-semibold pb-2 mx-4 mb-0 flex items-center gap-2">
+            Info
+          </h2>
+          <hr class="mb-4 border-t border-gray-300 dark:border-gray-700">
+          <div class="grid grid-cols-[190px_1fr] gap-y-3 gap-x-4 pl-4">
+            <div class="text-gray-500 dark:text-gray-400">
+              Enabled at build time
+            </div>
+            <div class="font-mono">
+              {{ swInfo.buildEnabled ? 'Yes' : 'No' }}
+            </div>
+            <div class="text-gray-500 dark:text-gray-400">
+              Enabled at development
+            </div>
+            <div class="font-mono">
+              {{ swInfo.devEnabled ? 'Yes' : 'No' }}
+            </div>
+            <template v-if="swInfo.devEnabled">
+              <div class="text-gray-500 dark:text-gray-400">
+                Current type
+              </div>
+              <div class="font-mono">
+                {{ swInfo.currentType || '--' }}
+              </div>
+            </template>
+          </div>
+        </section>
 
-        <div v-else class="px-4">
-          <ul class="flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden bg-gray-50/50 dark:bg-[#121212]/50">
-            <li
-              v-for="(chunk, idx) in swInfo.dependencies"
-              :key="`${swInfo.currentType}-${idx}`"
-              class="flex items-center gap-3 px-4 py-2.5 border-b border-gray-200 dark:border-gray-800 last:border-0 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            >
-              <span aria-hidden="true" class="block i-tabler:script text-gray-400 dark:text-gray-500 w-4 h-4 shrink-0" />
-              <span class="font-mono text-xs text-gray-700 dark:text-gray-300 truncate" :title="chunk">
-                {{ chunk }}
-              </span>
-            </li>
-          </ul>
-        </div>
-      </section>
+        <section>
+          <h2 id="chunks" tabindex="-1" class="text-md font-semibold pb-2 mx-4 mb-0 flex items-center gap-2">
+            Chunks
+          </h2>
+          <hr class="mb-4 border-t border-gray-300 dark:border-gray-700">
+
+          <div v-if="!swInfo.currentType || !swInfo.chunks || swInfo.chunks.length === 0" class="text-gray-500 dark:text-gray-400 pl-4">
+            No chunks available.
+          </div>
+
+          <div v-else class="px-4">
+            <ul class="flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden bg-gray-50/50 dark:bg-[#121212]/50">
+              <li
+                v-for="(chunk, idx) in swInfo.chunks"
+                :key="`${swInfo.currentType}-${idx}`"
+                class="flex items-center gap-3 px-4 py-2.5 border-b border-gray-200 dark:border-gray-800 last:border-0 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                <span aria-hidden="true" class="block i-tabler:script text-gray-400 dark:text-gray-500 w-4 h-4 shrink-0" />
+                <span class="font-mono text-xs text-gray-700 dark:text-gray-300 truncate" :title="chunk">
+                  {{ chunk }}
+                </span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 id="dependencies" tabindex="-1" class="text-md font-semibold pb-2 mx-4 mb-0 flex items-center gap-2">
+            Dependencies
+          </h2>
+          <hr class="mb-4 border-t border-gray-300 dark:border-gray-700">
+
+          <div v-if="!swInfo.currentType || !swInfo.dependencies || swInfo.dependencies.length === 0" class="text-gray-500 dark:text-gray-400 pl-4">
+            No dependencies available.
+          </div>
+
+          <div v-else class="px-4">
+            <ul class="flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden bg-gray-50/50 dark:bg-[#121212]/50">
+              <li
+                v-for="(dependency, idx) in swInfo.dependencies"
+                :key="`${swInfo.currentType}-${idx}`"
+                class="flex items-center gap-3 px-4 py-2.5 border-b border-gray-200 dark:border-gray-800 last:border-0 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                <span aria-hidden="true" class="block i-tabler:script text-gray-400 dark:text-gray-500 w-4 h-4 shrink-0" />
+                <span class="font-mono text-xs text-gray-700 dark:text-gray-300 truncate" :title="dependency">
+                  {{ dependency }}
+                </span>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
     </div>
+    <ServiceWorkerScrollSpy v-if="resolvedHeaders" :resolved-headers />
   </div>
 </template>

--- a/packages/unplugin-pwa/inspector/src/components/ServiceWorkerScrollSpy.vue
+++ b/packages/unplugin-pwa/inspector/src/components/ServiceWorkerScrollSpy.vue
@@ -10,7 +10,7 @@ const { resolvedHeaders } = defineProps<{
 const container = useTemplateRef('container')
 const marker = useTemplateRef('marker')
 
-const spyKey = 'vite-pwa-inspector:manifest:spy-pinned'
+const spyKey = 'vite-pwa-inspector:sw:spy-pinned'
 
 const isPinned = shallowRef(localStorage.getItem(spyKey) === 'true')
 watch(isPinned, (val) => {
@@ -23,7 +23,7 @@ function togglePin() {
 
 const { goTo } = useActiveAnchor(resolvedHeaders, container, marker)
 /* to test --scrollbar add this to style block: added at useActiveAnchor::onMounted
-.manifest-spy:before {
+.sw-spy:before {
   content: counter(val) "px";
   counter-reset: val tan(atan2(var(--scrollbar),1px));
 }
@@ -33,8 +33,8 @@ const { goTo } = useActiveAnchor(resolvedHeaders, container, marker)
 <template>
   <nav
     ref="container"
-    aria-labelledby="manifest-on-this-page"
-    class="manifest-spy absolute top-[0.5rem] z-10"
+    aria-labelledby="sw-on-this-page"
+    class="sw-spy absolute top-[0.5rem] z-10"
     :class="!isPinned ? 'group' : ''"
     style="right: var(--scrollbar, 17px); width: calc(210px - var(--scrollbar, 17px))"
   >
@@ -53,10 +53,10 @@ const { goTo } = useActiveAnchor(resolvedHeaders, container, marker)
       />
       <div class="flex items-center justify-between h-[32px] mb-1">
         <h2
-          id="manifest-on-this-page"
+          id="sw-on-this-page"
           class="text-sm font-semibold m-0 text-gray-500 dark:text-gray-400"
         >
-          On this manifest
+          On this service worker
         </h2>
         <button
           role="switch"
@@ -79,22 +79,13 @@ const { goTo } = useActiveAnchor(resolvedHeaders, container, marker)
       >
         <ul class="flex flex-col">
           <li>
-            <a href="/#identity" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'identity')">Identity</a>
+            <a href="/#info" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'info')">Info</a>
           </li>
           <li>
-            <a href="/#presentation" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'presentation')">Presentation</a>
+            <a href="/#chunks" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'chunks')">Chunks</a>
           </li>
           <li>
-            <a href="/#icons" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'icons')">Icons</a>
-          </li>
-          <li>
-            <a href="/#window-controls-overlay" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'window-controls-overlay')">Window Controls Overlay</a>
-          </li>
-          <li>
-            <a href="/#shortcuts" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'shortcuts')">Shortcuts</a>
-          </li>
-          <li>
-            <a href="/#screenshots" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'screenshots')">Screenshots</a>
+            <a href="/#dependencies" class="block h-[32px] leading-[32px] text-[14px] font-normal truncate text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 [&.active]:text-blue-600 dark:[&.active]:text-blue-400" @click="goTo($event, 'dependencies')">Dependencies</a>
           </li>
         </ul>
       </div>

--- a/packages/unplugin-pwa/inspector/src/pages/sw.vue
+++ b/packages/unplugin-pwa/inspector/src/pages/sw.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { onBeforeMount } from 'vue'
+import { onUnmounted } from 'vue'
 import { loadSWInfo } from '../api'
 import ServiceWorker from '../components/ServiceWorker.vue'
+import { currentSWInfo, swReady } from '../state'
 
-onBeforeMount(async () => {
-  await loadSWInfo()
+onUnmounted(() => {
+  swReady.value = false
+  currentSWInfo.value = undefined
 })
+
+await loadSWInfo()
+swReady.value = true
 </script>
 
 <template>

--- a/packages/unplugin-pwa/inspector/src/router.ts
+++ b/packages/unplugin-pwa/inspector/src/router.ts
@@ -1,9 +1,39 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { handleHotUpdate, routes } from 'vue-router/auto-routes'
+import { error, loadingSW, ready } from './state'
 
 export const router = createRouter({
   history: createWebHashHistory(),
   routes,
+})
+
+router.onError((err) => {
+  loadingSW.value = false
+  error.value = err
+})
+
+router.beforeEach(async (to) => {
+  if (to?.name === '/sw') {
+    loadingSW.value = true
+    await new Promise(resolve => setTimeout(resolve, 256))
+  }
+  else if (to?.name === '/') {
+    loadingSW.value = false
+    if (ready.value) {
+      error.value = undefined
+    }
+  }
+})
+
+router.afterEach((to) => {
+  if (to?.name === '/sw') {
+    loadingSW.value = false
+  }
+  else if (to?.name === '/') {
+    if (ready.value) {
+      error.value = undefined
+    }
+  }
 })
 
 if (import.meta.hot) {

--- a/packages/unplugin-pwa/inspector/src/state.ts
+++ b/packages/unplugin-pwa/inspector/src/state.ts
@@ -1,7 +1,9 @@
 import { computed, shallowRef } from 'vue'
 
 export const ready = shallowRef(false)
-export const error = shallowRef(false)
+export const error = shallowRef()
+export const swReady = shallowRef(false)
+export const loadingSW = shallowRef(true)
 
 export interface PWAConfiguration {
   version: string
@@ -17,6 +19,7 @@ export interface PWAConfiguration {
 
 export interface SWInfo {
   swType?: WorkerType
+  chunks?: string[]
   dependencies?: string[]
 }
 
@@ -28,6 +31,7 @@ export const swInfo = computed<{
   buildEnabled: boolean
   devEnabled: boolean
   currentType?: WorkerType
+  chunks?: string[]
   dependencies?: string[]
 }>(() => {
   const c = pwaConfiguration.value
@@ -53,14 +57,14 @@ export const swInfo = computed<{
     }
   }
 
-  let dependencies: string[] = [...i.dependencies ?? []]
+  let chunks: string[] = [...i.chunks ?? []]
 
   if (c.swType === 'classic-and-module') {
     if (i.swType === 'classic') {
-      dependencies = dependencies.filter(d => d.includes('-classic'))
+      chunks = chunks.filter(d => d.includes('-classic'))
     }
     else {
-      dependencies = dependencies.filter(d => d.includes('-module'))
+      chunks = chunks.filter(d => d.includes('-module'))
     }
   }
 
@@ -68,7 +72,8 @@ export const swInfo = computed<{
     buildEnabled: c.swEnabled,
     devEnabled: c.swDevEnabled,
     currentType: i.swType,
-    dependencies,
+    chunks,
+    dependencies: i.dependencies ?? [],
   }
 })
 

--- a/packages/unplugin-pwa/inspector/vite.config.ts
+++ b/packages/unplugin-pwa/inspector/vite.config.ts
@@ -9,8 +9,16 @@ import VueRouter from 'vue-router/vite'
 
 export default defineConfig({
   base: INSPECTOR_BASE_PATH_URL,
+  define: {
+    // disable options api in production build
+    __VUE_OPTIONS_API__: 'false',
+    // disable hydration mismatch details in production build
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+  },
   build: {
+    target: 'esnext',
     minify: false,
+    emptyOutDir: true,
     outDir: '../dist/inspector',
     rolldownOptions: {
       devtools: {},

--- a/packages/unplugin-pwa/package.json
+++ b/packages/unplugin-pwa/package.json
@@ -174,6 +174,7 @@
   },
   "devDependencies": {
     "@iconify-json/mdi": "catalog:inspector",
+    "@iconify-json/svg-spinners": "catalog:inspector",
     "@iconify-json/tabler": "catalog:inspector",
     "@types/react": "catalog:react",
     "@unocss/reset": "catalog:inspector",

--- a/packages/unplugin-pwa/package.json
+++ b/packages/unplugin-pwa/package.json
@@ -52,6 +52,7 @@
     "./node/html": "./dist/node/html.mjs",
     "./node/inject-generate-register-sw": "./dist/node/inject-generate-register-sw.mjs",
     "./node/inject-web-manifest-html-link": "./dist/node/inject-web-manifest-html-link.mjs",
+    "./node/inspector-utils": "./dist/node/inspector-utils.mjs",
     "./node/logs": "./dist/node/logs.mjs",
     "./node/prepare-pwa-context": "./dist/node/prepare-pwa-context.mjs",
     "./node/prepare-sw-names": "./dist/node/prepare-sw-names.mjs",

--- a/packages/unplugin-pwa/pwa-vite-devtools.d.ts
+++ b/packages/unplugin-pwa/pwa-vite-devtools.d.ts
@@ -15,6 +15,7 @@ declare module '@vitejs/devtools-kit' {
     }>
     'unplugin-pwa:service-worker-info': () => Promise<{
       swType?: WorkerType
+      chunks?: string[]
       dependencies?: string[]
     }>
   }

--- a/packages/unplugin-pwa/src/client/dev/vite/switcher.ts
+++ b/packages/unplugin-pwa/src/client/dev/vite/switcher.ts
@@ -331,11 +331,11 @@ if (import.meta.hot && import.meta.PWA_ESM_FALLBACK_SW) {
   let initialTop = 0
   let idleTimeout: ReturnType<typeof setTimeout>
 
-  // Separamos el estado físico de la red del estado de HMR
+  // We separate the physical state of the network from the HMR state
   let isOnline = navigator.onLine ?? true
-  let isHMRConnected = true // Por defecto asumimos que arranca conectado
+  let isHMRConnected = true // By default we assume it starts connected
 
-  // Única fuente de la verdad para saber si el componente está 100% operativo
+  // Single source of truth to know if the component is 100% operational
   const isConnected = () => isOnline && isHMRConnected
 
   const STORAGE_KEY = 'unplugin-pwa-switcher-pos'
@@ -403,7 +403,7 @@ if (import.meta.hot && import.meta.PWA_ESM_FALLBACK_SW) {
     }
   }
 
-  // Máquina de estados para la Conexión
+  // State machine for the Connection
   function checkConnection() {
     if (!isConnected()) {
       button.classList.add('is-offline')

--- a/packages/unplugin-pwa/src/node/inspector-utils.ts
+++ b/packages/unplugin-pwa/src/node/inspector-utils.ts
@@ -1,17 +1,15 @@
 import type { SWType } from '@composable-vite-pwa/workbox-build/types'
-import type { VitePWAStrategy } from '../../types'
-import type {
-  ViteBundler,
-  VitePWAPluginContext,
-} from '../vite-context'
+import type { Bundler, PWAPluginContext } from './context-types'
+import type { VitePWAStrategy } from './types'
 import path from 'node:path'
 import { normalizePath } from '@composable-vite-pwa/workbox-build/utils/resolve-sw-names'
-import packageJson from '../../../../package.json' with { type: 'json' }
+import packageJson from '../../package.json' with { type: 'json' }
 
 export function preparePWAConfigurationData<
+  B extends Bundler,
   UserStrategy extends VitePWAStrategy,
   T extends SWType,
->(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, T>) {
+>(ctx: PWAPluginContext<B, UserStrategy, T>) {
   const resolvedOptions = ctx.resolvedOptions
   const devOptions = resolvedOptions.devOptions
 
@@ -29,9 +27,10 @@ export function preparePWAConfigurationData<
 }
 
 export function prepareServiceWorkerData<
+  B extends Bundler,
   UserStrategy extends VitePWAStrategy,
   T extends SWType,
->(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, T>) {
+>(ctx: PWAPluginContext<B, UserStrategy, T>) {
   const root = ctx.rootDir
   const injectManifest = ctx.strategy === 'inject-manifest'
   const devOptions = ctx.resolvedOptions.devOptions

--- a/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
@@ -11,11 +11,11 @@ import {
   INSPECTOR_BASE_PATH,
   INSPECTOR_BASE_PATH_URL,
 } from '../../constants'
-import { inspectorWithInjectManifestWarning } from '../../logs'
 import {
   preparePWAConfigurationData,
   prepareServiceWorkerData,
-} from './inspector-utils'
+} from '../../inspector-utils'
+import { inspectorWithInjectManifestWarning } from '../../logs'
 
 export function DevtoolsPlugin<
   UserStrategy extends VitePWAStrategy,

--- a/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/devtools.ts
@@ -7,12 +7,15 @@ import type {
   VitePWAPluginContext,
 } from '../vite-context'
 import { fileURLToPath } from 'node:url'
-import packageJson from '../../../../package.json' with { type: 'json' }
 import {
   INSPECTOR_BASE_PATH,
   INSPECTOR_BASE_PATH_URL,
 } from '../../constants'
 import { inspectorWithInjectManifestWarning } from '../../logs'
+import {
+  preparePWAConfigurationData,
+  prepareServiceWorkerData,
+} from './inspector-utils'
 
 export function DevtoolsPlugin<
   UserStrategy extends VitePWAStrategy,
@@ -80,36 +83,13 @@ export function DevtoolsPlugin<
         context.rpc.register({
           name: 'unplugin-pwa:pwa-configuration',
           type: 'action',
-          handler: () => {
-            const resolvedOptions = ctx.resolvedOptions
-            const devOptions = resolvedOptions.devOptions
-            return {
-              version: packageJson.version,
-              base: ctx.base,
-              swEnabled: ctx.resolvedOptions.disable === false,
-              strategy: ctx.strategy,
-              swType: resolvedOptions.swType,
-              swDevEnabled: devOptions?.enabled === true,
-              currentSWType: ctx.dev.options.swType,
-              swNames: ctx.dev.options.swNames,
-              manifest: resolvedOptions.manifest,
-            }
-          },
+          handler: () => preparePWAConfigurationData(ctx),
         })
 
         context.rpc.register({
           name: 'unplugin-pwa:service-worker-info',
           type: 'action',
-          handler: () => {
-            const devOptions = ctx.resolvedOptions.devOptions
-            const dependencies = devOptions?.enabled === true && ctx.dev.options?.swAssetKeys
-              ? [...ctx.dev.options.swAssetKeys].filter(d => !d.endsWith('.map'))
-              : undefined
-            return {
-              swType: devOptions?.enabled === true ? ctx.dev.options?.swType : undefined,
-              dependencies,
-            }
-          },
+          handler: () => prepareServiceWorkerData(ctx),
         })
       },
     },

--- a/packages/unplugin-pwa/src/node/vite/plugins/inspector-utils.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/inspector-utils.ts
@@ -1,0 +1,58 @@
+import type { SWType } from '@composable-vite-pwa/workbox-build/types'
+import type { VitePWAStrategy } from '../../types'
+import type {
+  ViteBundler,
+  VitePWAPluginContext,
+} from '../vite-context'
+import path from 'node:path'
+import { normalizePath } from '@composable-vite-pwa/workbox-build/utils/resolve-sw-names'
+import packageJson from '../../../../package.json' with { type: 'json' }
+
+export function preparePWAConfigurationData<
+  UserStrategy extends VitePWAStrategy,
+  T extends SWType,
+>(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, T>) {
+  const resolvedOptions = ctx.resolvedOptions
+  const devOptions = resolvedOptions.devOptions
+
+  return {
+    version: packageJson.version,
+    base: ctx.base,
+    swEnabled: ctx.resolvedOptions.disable === false,
+    strategy: ctx.strategy,
+    swType: resolvedOptions.swType,
+    swDevEnabled: devOptions?.enabled === true,
+    currentSWType: ctx.dev.options.swType,
+    swNames: ctx.dev.options.swNames,
+    manifest: resolvedOptions.manifest,
+  }
+}
+
+export function prepareServiceWorkerData<
+  UserStrategy extends VitePWAStrategy,
+  T extends SWType,
+>(ctx: VitePWAPluginContext<ViteBundler, UserStrategy, T>) {
+  const root = ctx.rootDir
+  const injectManifest = ctx.strategy === 'inject-manifest'
+  const devOptions = ctx.resolvedOptions.devOptions
+  let chunks = devOptions?.enabled === true && ctx.dev.options?.swAssetKeys
+    ? [...ctx.dev.options.swAssetKeys].filter(d => !d.endsWith('.map'))
+    : undefined
+
+  let dependencies = [...ctx.sources].map(d => normalizePath(path.relative(root, d)))
+
+  if (injectManifest) {
+    if (chunks) {
+      const swName = `${ctx.base}${ctx.dev.options.swNames.name}`
+      chunks = chunks.map(c => c === swName ? c : normalizePath(path.relative(root, c)))
+    }
+    const filename = ctx.resolvedOptions.injectManifest!.swSrc
+    dependencies = dependencies.filter(c => c !== filename)
+  }
+
+  return {
+    swType: devOptions?.enabled === true ? ctx.dev.options?.swType : undefined,
+    chunks,
+    dependencies,
+  }
+}

--- a/packages/unplugin-pwa/src/node/vite/plugins/inspector.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/inspector.ts
@@ -6,12 +6,15 @@ import type {
   VitePWAPluginContext,
 } from '../vite-context'
 import { fileURLToPath } from 'node:url'
-import packageJson from '../../../../package.json'
 import {
   INSPECTOR_BASE_PATH_API,
   INSPECTOR_BASE_PATH_URL,
 } from '../../constants'
 import { inspectorWithInjectManifestWarning } from '../../logs'
+import {
+  preparePWAConfigurationData,
+  prepareServiceWorkerData,
+} from './inspector-utils'
 
 export function InspectorPlugin<
   UserStrategy extends VitePWAStrategy,
@@ -67,17 +70,7 @@ export function InspectorPlugin<
 
         if (req.url === '/') {
           res.setHeader('Content-Type', 'application/json')
-          res.write(JSON.stringify({
-            version: packageJson.version,
-            base: ctx.base,
-            swEnabled: ctx.resolvedOptions.disable === false,
-            strategy: ctx.strategy,
-            swType: resolvedOptions.swType,
-            swDevEnabled: devOptions?.enabled === true,
-            currentSWType: ctx.dev.options.swType,
-            swNames: ctx.dev.options.swNames,
-            manifest: resolvedOptions.manifest,
-          }))
+          res.write(JSON.stringify(preparePWAConfigurationData(ctx)))
           res.end()
           return
         }
@@ -96,15 +89,8 @@ export function InspectorPlugin<
         }
 
         if (req.url.startsWith('/sw')) {
-          const devOptions = ctx.resolvedOptions.devOptions
-          const dependencies = devOptions?.enabled === true && ctx.dev.options?.swAssetKeys
-            ? [...ctx.dev.options.swAssetKeys].filter(d => !d.endsWith('.map'))
-            : undefined
           res.setHeader('Content-Type', 'application/json')
-          res.write(JSON.stringify({
-            swType: devOptions?.enabled === true ? ctx.dev.options?.swType : undefined,
-            dependencies,
-          }))
+          res.write(JSON.stringify(prepareServiceWorkerData(ctx)))
           res.end()
           return
         }

--- a/packages/unplugin-pwa/src/node/vite/plugins/inspector.ts
+++ b/packages/unplugin-pwa/src/node/vite/plugins/inspector.ts
@@ -10,11 +10,11 @@ import {
   INSPECTOR_BASE_PATH_API,
   INSPECTOR_BASE_PATH_URL,
 } from '../../constants'
-import { inspectorWithInjectManifestWarning } from '../../logs'
 import {
   preparePWAConfigurationData,
   prepareServiceWorkerData,
-} from './inspector-utils'
+} from '../../inspector-utils'
+import { inspectorWithInjectManifestWarning } from '../../logs'
 
 export function InspectorPlugin<
   UserStrategy extends VitePWAStrategy,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ catalogs:
     '@iconify-json/mdi':
       specifier: ^1.2.3
       version: 1.2.3
+    '@iconify-json/svg-spinners':
+      specifier: ^1.2.4
+      version: 1.2.4
     '@iconify-json/tabler':
       specifier: ^1.2.35
       version: 1.2.35
@@ -1105,6 +1108,9 @@ importers:
       '@iconify-json/mdi':
         specifier: catalog:inspector
         version: 1.2.3
+      '@iconify-json/svg-spinners':
+        specifier: catalog:inspector
+        version: 1.2.4
       '@iconify-json/tabler':
         specifier: catalog:inspector
         version: 1.2.35
@@ -2427,6 +2433,9 @@ packages:
 
   '@iconify-json/simple-icons@1.2.90':
     resolution: {integrity: sha512-zt2o2ZvQpHVvZJARIkZ51RnaHY2oqcPJMvHE+mVnxkSr+c33fnX4gciiXu+wyX5ei+s0qbVX1wD0DWBbaGBYMA==}
+
+  '@iconify-json/svg-spinners@1.2.4':
+    resolution: {integrity: sha512-ayn0pogFPwJA1WFZpDnoq9/hjDxN+keeCMyThaX4d3gSJ3y0mdKUxIA/b1YXWGtY9wVtZmxwcvOIeEieG4+JNg==}
 
   '@iconify-json/tabler@1.2.35':
     resolution: {integrity: sha512-/sJMqHvh5ZWrEERVfDCT5NjVDeKJdhosFtKjJofAVl+P/3AzLiryOQw7WvrfDF25Xa5N/eoOQ15Y1jnhYXxBoQ==}
@@ -11079,6 +11088,10 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/simple-icons@1.2.90':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/svg-spinners@1.2.4':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,6 +71,7 @@ catalogs:
     eslint-plugin-antfu: ^3.2.2
   inspector:
     '@iconify-json/mdi': ^1.2.3
+    '@iconify-json/svg-spinners': ^1.2.4
     '@iconify-json/tabler': ^1.2.35
     '@unocss/reset': ^66.7.5
     '@vitejs/devtools': ^0.4.1


### PR DESCRIPTION
This PR includes:
- add SW chunks
- normalize paths at chunks and dependencies relative to project root
- exclude SW at dependencies when using inject manifest strategy
- add service worker spy
- add new module for pwa configuration and sw info: use this new module at devtools and inspector plugins