### PR TITLE
fix(nuxt): register pwa inspector as nuxt devtools tab when required

### DIFF
--- a/packages/nuxt/src/internal/devtools-custom-tabs-hook.ts
+++ b/packages/nuxt/src/internal/devtools-custom-tabs-hook.ts
@@ -16,7 +16,10 @@ export function devtoolsCustomTabsHook<
   ctx: NPWAC,
 ): import('@nuxt/schema').NuxtHooks['devtools:customTabs'] {
   return (tabs) => {
-    if (ctx.resolvedOptions.devOptions?.inspector) {
+    // register the inspector only when using standalone
+    // adding pwa inspector to nuxt devtools will require some changes
+    // we remove the entry at nuxt devtools, pwa inspector is present at vite devtools
+    if (ctx.resolvedOptions.devOptions?.inspector === 'standalone') {
       tabs.push({
         title: 'Vite PWA Inspector',
         name: 'vite-pwa:nuxt:inspector',


### PR DESCRIPTION
When using vite devtools, we're registering pwa inspector twice, at vite devtools and as a tab at nuxt devtools.

When opening the pwa inspector from nuxt devtools, it will fail, we need some changes.

This PR will prevent adding pwa inspector as a tab at nuxt devtools when using vite devtools (nuxt devtools v4): the pwa inspector only at vite devtools.

For nuxt devtools v3 (nuxt < 5), the pwa inspector must be `standalone` then the pwa inspector will be added as a tab at nuxt devtools.

<details>
<summary>pwa inspector error when opening pwa inspector tab at nuxt devtools v4</summary>

<img width="1684" height="678" alt="image" src="https://github.com/user-attachments/assets/ce419a3e-3e45-4ff2-bab6-2d774ced2904" />
</details>