### PR TITLE
docs: add README for astro, sveltekit and workbox-window packages (#41)

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,0 +1,72 @@
+# @composable-vite-pwa/astro
+
+Zero-config PWA integration for [Astro](https://astro.build).
+
+> **⚠️ This project is not yet ready for production.** APIs may change and documentation is incomplete.
+
+## Installation
+
+```bash
+pnpm add @composable-vite-pwa/astro
+```
+
+## Peer dependencies
+
+Package	Version	Required
+astro	^5.0.0 || ^6.0.0 || ^7.0.0	Yes
+@vite-pwa/assets-generator	^1.0.0 || ^2.0.0	Optional
+magicast	^0.5.0	Optional (only for generateSW strategy)
+rolldown	^1.0.0-0	Optional (only for buildSW strategy)
+
+Requires Node.js >= 22.14.0. 
+
+## Usage 
+
+Add the integration to your `astro.config.mjs`:
+
+```
+import { defineConfig } from 'astro/config'
+
+import { AstroPWAIntegration } from '@composable-vite-pwa/astro'
+
+export default defineConfig({
+
+  integrations: [
+
+    AstroPWAIntegration({
+
+      // strategy: 'injectManifest',
+
+      // injectManifest: {
+
+      //   swSrc: 'src/sw.ts',
+
+      // },
+
+    }),
+
+  ],
+
+})
+``` 
+### Strategies 
+
+The integration supports two strategies: 
+
+* `injectManifest` (default) — uses your own service worker source file. 
+* `generateSW`  — auto-generates a service worker using Workbox. 
+* `buildSW` — builds a dual (classic + module) service worker (requires `rolldown`).
+
+### Breaking changes from `@vite-pwa/astro` 
+
+Before (@vite-pwa/astro)	Now (@composable-vite-pwa/astro)
+workbox option	Deprecated. Use generateSW instead.
+srcDir option	Removed. Use relative path in swSrc (e.g. src/sw.ts).
+injectRegister	Removed. Use virtual modules instead.
+Service worker templates	Removed. Use a custom service worker.
+Node.js >= 16	Node.js >= 22.14.0
+Vite 3/4	Vite >= 5 (Vite 3/4 may or may not work) 
+
+### License 
+
+[MIT](LICENSE)

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -1,0 +1,88 @@
+# @composable-vite-pwa/sveltekit
+
+Zero-config PWA integration for [SvelteKit](https://kit.svelte.dev).
+
+> **⚠️ This project is not yet ready for production.** APIs may change and documentation is incomplete.
+
+## Installation
+
+```bash
+pnpm add @composable-vite-pwa/sveltekit
+```
+
+### Peer dependencies 
+
+Package	Version	Required
+@sveltejs/kit	^1.3.1 || ^2.0.1 || ^3.0.0-0	Yes
+@vite-pwa/assets-generator	^1.0.0 || ^2.0.0	Optional
+magicast	^0.5.0	Optional (only for generateSW strategy)
+rolldown	^1.0.0-0	Optional (only for buildSW strategy)
+
+Requires Node.js >= 22.14.0.
+
+### Usage 
+
+Replace `sveltekit()` with `withPwa()` in your `vite.config.ts`:
+
+```ts
+import { withPwa } from '@composable-vite-pwa/sveltekit'
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+
+  plugins: [
+
+    withPwa(
+
+      // optional sveltekit config
+
+      {},
+
+      // PWA options
+
+      {
+
+        // strategy: 'injectManifest',
+
+        // injectManifest: {
+
+        //   swSrc: 'src/sw.ts',
+
+        // },
+
+      },
+
+    ),
+
+  ],
+
+})
+```
+The first argument is the same config you would pass to sveltekit(). The second argument is the PWA configuration.
+
+### Legacy export
+A legacy adapter is available at @composable-vite-pwa/sveltekit/legacy for projects that need backward-compatible behavior.
+
+### Strategies
+The integration supports two strategies:
+
+- `injectManifest` (default) — uses your own service worker source file.
+- `generateSW` — auto-generates a service worker using Workbox.
+- `buildSW` — builds a dual (classic + module) service worker (requires rolldown).
+
+### Breaking changes from  `@vite-pwa/sveltekit`
+
+Before (@vite-pwa/sveltekit)	Now (@composable-vite-pwa/sveltekit)
+`workbox` option	Deprecated. Use `generateSW` instead.
+`srcDir` option	Removed. Use relative path in `swSrc` (e.g. `src/sw.ts`).
+`injectRegister`	Removed. Use virtual modules instead.
+Service worker templates	Removed. Use a custom service worker.
+Node.js >= 16	Node.js >= 22.14.0
+Vite 3/4	Vite >= 5 (Vite 3/4 may or may not work)
+
+### License
+[MIT](LICENSE)
+
+
+

--- a/packages/workbox/window/README.md
+++ b/packages/workbox/window/README.md
@@ -1,0 +1,81 @@
+# @composable-vite-pwa/workbox-window
+
+A helper library that simplifies communication with Workbox packages running in a service worker, and manages the service worker lifecycle.
+
+This is a composable rework of the original [workbox-window](https://developer.chrome.com/docs/workbox/modules/workbox-window/) package.
+
+> **⚠️ This project is not yet ready for production.** APIs may change and documentation is incomplete.
+
+## Installation
+
+```bash
+pnpm add @composable-vite-pwa/workbox-window
+```
+
+## Usage 
+
+### Registering a service worker 
+
+```ts
+import { Workbox } from '@composable-vite-pwa/workbox-window'
+
+if ('serviceWorker' in navigator) {
+
+  const wb = new Workbox('/sw.js')
+
+  wb.addEventListener('installed', (event) => {
+
+    if (event.isUpdate) {
+
+      console.log('New service worker installed — content updated.')
+
+    } else {
+
+      console.log('Service worker installed for the first time.')
+
+    }
+
+  })
+
+  wb.register()
+
+}
+```
+### Sending a message to the service worker 
+
+```ts
+import { messageSW } from '@composable-vite-pwa/workbox-window'
+
+// Assuming `wb` is a Workbox instance
+
+const sw = wb.active ?? wb.waiting ?? wb.installing
+
+if (sw) {
+
+  const response = await messageSW(sw, { type: 'GET_CACHED_URLS' })
+
+  console.log(response)
+
+}
+```
+### ESM service worker detection 
+
+```ts
+import { isSupported } from '@composable-vite-pwa/workbox-window/esm-sw-detector'
+
+const supported = await isSupported()
+
+if (supported) {
+
+  // ESM service workers are supported in this browser
+
+}
+```
+### Exports 
+
+Entry	Description
+`@composable-vite-pwa/workbox-window`	`Workbox class`, `messageSW helper`, and WorkboxEvent types.
+`@composable-vite-pwa/workbox-window/esm-sw-detector`	`isSupported()` — detects ESM service worker support.
+
+### License
+[MIT](LICENSE)


### PR DESCRIPTION
Add missing README files for three packages that had no documentation:

* packages/astro: documents AstroPWAIntegration usage, peer dependencies, strategies, and breaking changes from the old @vite-pwa/astro.
* packages/sveltekit: documents withPwa() usage, legacy export, strategies, and breaking changes from the old @vite-pwa/sveltekit.
* packages/workbox/window: documents Workbox class, messageSW helper, ESM service worker detection, and subpath exports.

Closes #41.