### PR TITLE
fix: copy relative importScripts assets in injectManifest

### DIFF
--- a/packages/workbox/build/src/utils/build-inject-manifest.ts
+++ b/packages/workbox/build/src/utils/build-inject-manifest.ts
@@ -128,6 +128,15 @@ export async function buildInjectManifest(
     await fsp.writeFile(destPath, finalCode, 'utf-8')
   }
 
+  // Copy files referenced by importScripts() in the SW source
+  const swSrcDir = path.dirname(path.resolve(process.cwd(), options.swSrc))
+  const copiedImportScripts = await copyImportScriptsAssets(
+    cleanCode,
+    swSrcDir,
+    destDir,
+  )
+  filePaths.push(...copiedImportScripts)
+
   logInjectManifestResult(
     { count, size, warnings, filePaths },
     performance.now() - buildStart,
@@ -174,4 +183,72 @@ function extractSourceMap(code: string): { code: string, mapComment?: string } {
   const cleanCode = code.replace(workboxSourcemapRegex, '').trimEnd()
 
   return { code: cleanCode, mapComment }
+}
+
+/**
+ * Matches importScripts() calls with string arguments.
+ * Handles single and double quotes, multiple arguments.
+ * Examples:
+ *   importScripts('./chunk.js')
+ *   importScripts("./a.js", "./b.js")
+ *   importScripts('./chunk.js', './helper.js')
+ */
+const IMPORT_SCRIPTS_REGEX = /importScripts\s*\(\s*((?:['"][^'"]+['"]\s*(?:,\s*)?)+)\)/g
+const IMPORT_SCRIPTS_ARG_REGEX = /['"]([^'"]+)['"]/g
+
+/**
+ * Parse importScripts() calls in SW source code and return
+ * relative file paths (those starting with './' or '../').
+ */
+export function parseImportScriptsRelativePaths(code: string): string[] {
+  const paths: string[] = []
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = IMPORT_SCRIPTS_REGEX.exec(code)) !== null) {
+    const argsStr = match[1]!
+    let argMatch: RegExpExecArray | null
+    IMPORT_SCRIPTS_ARG_REGEX.lastIndex = 0
+    // eslint-disable-next-line no-cond-assign
+    while ((argMatch = IMPORT_SCRIPTS_ARG_REGEX.exec(argsStr)) !== null) {
+      const arg = argMatch[1]!
+      if (arg.startsWith('./') || arg.startsWith('../')) {
+        paths.push(arg)
+      }
+    }
+  }
+
+  return paths
+}
+
+/**
++ * Copy files referenced by importScripts() from the SW source
+ * directory to the SW destination directory.
+ */
+export async function copyImportScriptsAssets(
+  code: string,
+  swSrcDir: string,
+  swDestDir: string,
+): Promise<string[]> {
+  const relativePaths = parseImportScriptsRelativePaths(code)
+  if (!relativePaths.length)
+    return []
+  const copied: string[] = []
+  for (const relPath of relativePaths) {
+    const srcFile = path.resolve(swSrcDir, relPath)
+    const destFile = path.resolve(swDestDir, path.basename(relPath))
+
+    try {
+      await fsp.access(srcFile, fs.constants.F_OK)
+    }
+    catch {
+      // Source file doesn't exist, skip silently
+      continue
+    }
+
+    await fsp.mkdir(path.dirname(destFile), { recursive: true })
+    await fsp.copyFile(srcFile, destFile)
+    copied.push(destFile)
+  }
+
+  return copied
 }

--- a/packages/workbox/build/test/inject-manifest.spec.ts
+++ b/packages/workbox/build/test/inject-manifest.spec.ts
@@ -91,4 +91,60 @@ describe('inject-manifest', () => {
       logLevel: 'silent',
     })).rejects.toThrow(errors['invalid-sw-src'])
   })
+  testInjectManifest('copies relative importScripts assets to dest directory', async ({ sandbox }) => {
+    // Create a chunk file that the SW references via importScripts
+    const chunkPath = path.resolve(sandbox, 'chunk.js')
+    await fs.writeFile(chunkPath, 'self.addEventListener("fetch", () => {})', 'utf-8')
+
+    // Create SW source with importScripts referencing the chunk
+    const swSrc = normalizePath(path.resolve(sandbox, 'sw.js'))
+    await fs.writeFile(swSrc, [
+      'importScripts(\'./chunk.js\')',
+      'self.__WB_MANIFEST',
+    ].join('\n'), 'utf-8')
+
+    const swDest = normalizePath(path.resolve(sandbox, 'dist', 'sw.js'))
+    const globDirectory = normalizePath(sandbox)
+
+    const result = await injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })
+
+    // The chunk file should have been copied to the dest directory
+    const destChunk = path.resolve(sandbox, 'dist', 'chunk.js')
+    const chunkContent = await fs.readFile(destChunk, 'utf-8')
+    expect(chunkContent).toContain('fetch')
+
+    // The copied file should be included in filePaths
+    expect(result.filePaths).toContain(normalizePath(destChunk))
+  })
+
+  testInjectManifest('skips missing importScripts assets without error', async ({ sandbox }) => {
+    // SW references a chunk that doesn't exist on disk
+    const swSrc = normalizePath(path.resolve(sandbox, 'sw.js'))
+    await fs.writeFile(swSrc, [
+      'importScripts(\'./missing-chunk.js\')',
+      'self.__WB_MANIFEST',
+    ].join('\n'), 'utf-8')
+
+    const swDest = normalizePath(path.resolve(sandbox, 'dist', 'sw.js'))
+    const globDirectory = normalizePath(sandbox)
+
+    // Should not throw
+    const result = await injectManifest({
+      swSrc,
+      swDest,
+      globDirectory,
+      globPatterns: ['**/*.js'],
+      injectionPoint: 'self.__WB_MANIFEST',
+      logLevel: 'silent',
+    })
+
+    expect(result.filePaths).not.toContain('missing-chunk.js')
+  })
 })


### PR DESCRIPTION
## Description

When using `injectManifest`, if the SW source file contains `importScripts('./chunk.js')` with relative paths, those referenced files are not copied to the output directory alongside the built SW. This causes 404 errors at runtime when the service worker tries to load the chunks.

## Changes

- Added `parseImportScriptsRelativePaths()` to extract relative paths (`./` or `../`) from `importScripts()` calls in the SW source code
- Added `copyImportScriptsAssets()` to copy referenced files from the SW source directory to the SW destination directory
- Integrated into `buildInjectManifest()` after writing the SW output file
- Missing source files are skipped silently (no error thrown)
- Copied files are included in the returned `filePaths` array

## Not changed

- Absolute URLs in `importScripts()` (e.g. `https://...`) are ignored — only relative paths are processed
- The `buildSW` and `generateSW` strategies are unaffected
- The `buildSW` classic chunk transform (`transform-classic-chunk.ts`) already handles its own `importScripts` generation

Closes #37